### PR TITLE
feat(origin-247-certificate): forUnitTests module

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,14 +1,15 @@
 lockfileVersion: 5.3
 
 specifiers:
-  '@energyweb/issuer': 3.2.1-alpha.1623138698.0
-  '@energyweb/issuer-api': 0.2.1-alpha.1623138698.0
-  '@energyweb/origin-backend-utils': 1.5.2-alpha.1623138698.0
-  '@energyweb/utils-general': 11.0.3-alpha.1623138698.0
+  '@energyweb/issuer': 3.2.1-alpha.1625573089.0
+  '@energyweb/issuer-api': 0.2.1-alpha.1625573089.0
+  '@energyweb/origin-backend-utils': 1.5.2-alpha.1625573089.0
+  '@energyweb/utils-general': 11.0.3-alpha.1625573089.0
   '@nestjs/bull': 0.3.1
   '@nestjs/common': 7.6.18
   '@nestjs/core': 7.6.18
   '@nestjs/cqrs': 7.0.1
+  '@nestjs/passport': 7.1.5
   '@nestjs/platform-express': 7.6.18
   '@nestjs/testing': 7.6.18
   '@nestjs/typeorm': 7.1.5
@@ -29,14 +30,15 @@ specifiers:
   wait-on: 5.3.0
 
 dependencies:
-  '@energyweb/issuer': 3.2.1-alpha.1623138698.0
-  '@energyweb/issuer-api': 0.2.1-alpha.1623138698.0_84d2e8496da2b35f72ec1aae830fb752
-  '@energyweb/origin-backend-utils': 1.5.2-alpha.1623138698.0_@nestjs+platform-express@7.6.18
-  '@energyweb/utils-general': 11.0.3-alpha.1623138698.0
+  '@energyweb/issuer': 3.2.1-alpha.1625573089.0
+  '@energyweb/issuer-api': 0.2.1-alpha.1625573089.0_84d2e8496da2b35f72ec1aae830fb752
+  '@energyweb/origin-backend-utils': 1.5.2-alpha.1625573089.0_@nestjs+platform-express@7.6.18
+  '@energyweb/utils-general': 11.0.3-alpha.1625573089.0
   '@nestjs/bull': 0.3.1_c86fa2ed7bc9e7a48760c2e5795b24d0
   '@nestjs/common': 7.6.18
   '@nestjs/core': 7.6.18_e6f0514ea3d89219387f66417a78dd96
   '@nestjs/cqrs': 7.0.1_2664420588e0901c7943acb4693cbaf4
+  '@nestjs/passport': 7.1.5_fd45a09fcff1f973814c588ad08d33e0
   '@nestjs/platform-express': 7.6.18_2664420588e0901c7943acb4693cbaf4
   '@nestjs/testing': 7.6.18_9cd0f963ae6f35bf288217e4f1c45cb4
   '@nestjs/typeorm': 7.1.5_476bd709bf4288b37cfeb220ce38756a
@@ -407,24 +409,24 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@energyweb/issuer-api/0.2.1-alpha.1623138698.0_84d2e8496da2b35f72ec1aae830fb752:
-    resolution: {integrity: sha512-uJQQOraybNo1uXPHKUv7fLzWtivUncTYeGeM7uuWFW9MbnnbTCJ6cum72tqA9Ny0vcwvIsKyx/YW8ttocg4Uew==}
+  /@energyweb/issuer-api/0.2.1-alpha.1625573089.0_84d2e8496da2b35f72ec1aae830fb752:
+    resolution: {integrity: sha512-k/7r1C1rXrhJII/Q9RPIZ9Z9K7JCQVTSoWbwigL+4+ntIi7FbctTZeZr0J9r2PHxn3TFfQWNr/F0CgoHggr4WQ==}
     hasBin: true
     dependencies:
-      '@energyweb/issuer': 3.2.1-alpha.1623138698.0
-      '@energyweb/origin-backend-core': 8.0.2-alpha.1623138698.0
-      '@energyweb/origin-backend-utils': 1.5.2-alpha.1623138698.0_1ba596b413b1fee075d934d39aaa8f96
-      '@energyweb/utils-general': 11.0.3-alpha.1623138698.0
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/config': 0.6.3_@nestjs+common@7.6.17+rxjs@6.6.7
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
-      '@nestjs/cqrs': 7.0.1_e8830d008f1c8c5b585245e04815667a
-      '@nestjs/passport': 7.1.5_6b9aabeef2ebcf8aef3549ea590af16a
-      '@nestjs/schedule': 0.4.3_@nestjs+common@7.6.17
-      '@nestjs/swagger': 4.8.0_f5f7353216d93413c7498d2c55f68a84
-      '@nestjs/typeorm': 7.1.5_df95866fd57fe3c3af7787015f39999a
+      '@energyweb/issuer': 3.2.1-alpha.1625573089.0
+      '@energyweb/origin-backend-core': 8.0.2-alpha.1625573089.0
+      '@energyweb/origin-backend-utils': 1.5.2-alpha.1625573089.0_1ba596b413b1fee075d934d39aaa8f96
+      '@energyweb/utils-general': 11.0.3-alpha.1625573089.0
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/config': 0.6.3_@nestjs+common@7.6.18+rxjs@6.6.7
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
+      '@nestjs/cqrs': 7.0.1_31f45c01bada0af28c4fa5d0ce49c429
+      '@nestjs/passport': 7.1.6_fd45a09fcff1f973814c588ad08d33e0
+      '@nestjs/schedule': 0.4.3_@nestjs+common@7.6.18
+      '@nestjs/swagger': 4.8.2_74f4554e640a8c7b6751d53d8346c01a
+      '@nestjs/typeorm': 7.1.5_c9af0b2f72f65b72c7522ad6634c8b35
       class-validator: 0.13.1
-      ethers: 5.3.0
+      ethers: 5.4.1
       ganache-cli: 6.12.2
       moment: 2.29.1
       moment-range: 4.0.2_moment@2.29.1
@@ -450,15 +452,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@energyweb/issuer/3.2.1-alpha.1623138698.0:
-    resolution: {integrity: sha512-gLrJ/d3tQXPDBhsksh6c7lq/+owenBEJUDMP2O4VHm4uZYWyJMtc2zFxgvcSUKI0QGhca9tRI6pR8SJ3hTSYmw==}
+  /@energyweb/issuer/3.2.1-alpha.1625573089.0:
+    resolution: {integrity: sha512-88v7jQWUC0rH6CdaXKtkMBXo1h618SUiaRdvxYjnSwCLMvmSeZ0FrSMFkd7mmJ3l1RVbiCRPQHmY5oSu6KT/+g==}
     dependencies:
-      '@energyweb/utils-general': 11.0.3-alpha.1623138698.0
-      '@ethersproject/abi': 5.3.0
-      '@ethersproject/contracts': 5.3.0
-      '@ethersproject/providers': 5.3.0
+      '@energyweb/utils-general': 11.0.3-alpha.1625573089.0
+      '@ethersproject/abi': 5.4.0
+      '@ethersproject/contracts': 5.4.0
+      '@ethersproject/providers': 5.4.1
       dotenv: 10.0.0
-      ethers: 5.3.0
+      ethers: 5.4.1
       ganache-cli: 6.12.2
       moment: 2.29.1
       precise-proofs-js: 1.2.0
@@ -468,25 +470,25 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@energyweb/origin-backend-core/8.0.2-alpha.1623138698.0:
-    resolution: {integrity: sha512-03KeG7JPR7yxGcJTnQf2piRyBa1itlusxFtU1F60jpTpt5g92+zTrzQ+h1VnrANXRVFapDct2Ebm4vENJUBvoA==}
+  /@energyweb/origin-backend-core/8.0.2-alpha.1625573089.0:
+    resolution: {integrity: sha512-RupSgbS+FQpfQloaVxitj9K2cK3IkBnE8J8Y9mr+Sy5i2/CgvbU4QbHAnw2UfwuPecCXI9FPUl4+39RyANARMQ==}
     dependencies:
       class-transformer: 0.3.1
       class-validator: 0.13.1
-      ethers: 5.3.0
+      ethers: 5.4.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@energyweb/origin-backend-utils/1.5.2-alpha.1623138698.0_1ba596b413b1fee075d934d39aaa8f96:
-    resolution: {integrity: sha512-uSuW4Repz1hGjsZ0Ezm3OaSxqwP4zjvJD4S/QVCVOt9s7XGIQI9wC04tbjCVT4XWKlAObPbWSuAtWVETmClxmQ==}
+  /@energyweb/origin-backend-utils/1.5.2-alpha.1625573089.0_1ba596b413b1fee075d934d39aaa8f96:
+    resolution: {integrity: sha512-a5K0VPYxsTRLUaqmvLB8JcjVy7u2vIXr7k7RC6GUuGTnNpuXGu/uinjQnKp+eMmJ+aqB9NTxSyT+Z5guCx6PGQ==}
     dependencies:
-      '@energyweb/origin-backend-core': 8.0.2-alpha.1623138698.0
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/config': 0.6.3_@nestjs+common@7.6.17+rxjs@6.6.7
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
-      '@nestjs/swagger': 4.8.0_f5f7353216d93413c7498d2c55f68a84
+      '@energyweb/origin-backend-core': 8.0.2-alpha.1625573089.0
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/config': 0.6.3_@nestjs+common@7.6.18+rxjs@6.6.7
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
+      '@nestjs/swagger': 4.8.2_74f4554e640a8c7b6751d53d8346c01a
       bn.js: 5.2.0
       class-validator: 0.13.1
       polly-js: 1.8.2
@@ -507,14 +509,14 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@energyweb/origin-backend-utils/1.5.2-alpha.1623138698.0_@nestjs+platform-express@7.6.18:
-    resolution: {integrity: sha512-uSuW4Repz1hGjsZ0Ezm3OaSxqwP4zjvJD4S/QVCVOt9s7XGIQI9wC04tbjCVT4XWKlAObPbWSuAtWVETmClxmQ==}
+  /@energyweb/origin-backend-utils/1.5.2-alpha.1625573089.0_@nestjs+platform-express@7.6.18:
+    resolution: {integrity: sha512-a5K0VPYxsTRLUaqmvLB8JcjVy7u2vIXr7k7RC6GUuGTnNpuXGu/uinjQnKp+eMmJ+aqB9NTxSyT+Z5guCx6PGQ==}
     dependencies:
-      '@energyweb/origin-backend-core': 8.0.2-alpha.1623138698.0
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/config': 0.6.3_@nestjs+common@7.6.17+rxjs@6.6.7
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
-      '@nestjs/swagger': 4.8.0_f9100682edd43d2074cb46854e706969
+      '@energyweb/origin-backend-core': 8.0.2-alpha.1625573089.0
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/config': 0.6.3_@nestjs+common@7.6.18+rxjs@6.6.7
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
+      '@nestjs/swagger': 4.8.2_bbb437c2acc4c4104a11b39098b7f11a
       bn.js: 5.2.0
       class-validator: 0.13.1
       polly-js: 1.8.2
@@ -535,12 +537,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@energyweb/utils-general/11.0.3-alpha.1623138698.0:
-    resolution: {integrity: sha512-DQmJAxZEa91M6xeC/Xxeq3ybT/EemwKp0br5PfWObBRJpwfUypUgAdJ7roYazqjHvxQhUEIgq2wymsYs8q7hPg==}
+  /@energyweb/utils-general/11.0.3-alpha.1625573089.0:
+    resolution: {integrity: sha512-ou7FZ8lOtD7MqJ5TAwXm8Lhfo5zq7InQ6c3Ic/EzlfESMH5KicUko3vz7V7UlvRxxYv3r652L8N3x9JzaPFYOg==}
     dependencies:
       chai: 4.3.0
       eth-sig-util: 2.5.4
-      ethers: 5.3.0
+      ethers: 5.4.1
       jsonschema: 1.4.0
       moment: 2.29.1
       winston: 3.3.3
@@ -577,6 +579,20 @@ packages:
       '@ethersproject/strings': 5.3.0
     dev: false
 
+  /@ethersproject/abi/5.4.0:
+    resolution: {integrity: sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==}
+    dependencies:
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/hash': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/strings': 5.4.0
+    dev: false
+
   /@ethersproject/abstract-provider/5.3.0:
     resolution: {integrity: sha512-1+MLhGP1GwxBDBNwMWVmhCsvKwh4gK7oIfOrmlmePNeskg1NhIrYssraJBieaFNHUYfKEd/1DjiVZMw8Qu5Cxw==}
     dependencies:
@@ -589,6 +605,18 @@ packages:
       '@ethersproject/web': 5.3.0
     dev: false
 
+  /@ethersproject/abstract-provider/5.4.0:
+    resolution: {integrity: sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/networks': 5.4.1
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      '@ethersproject/web': 5.4.0
+    dev: false
+
   /@ethersproject/abstract-signer/5.3.0:
     resolution: {integrity: sha512-w8IFwOYqiPrtvosPuArZ3+QPR2nmdVTRrVY8uJYL3NNfMmQfTy3V3l2wbzX47UUlNbPJY+gKvzJAyvK1onZxJg==}
     dependencies:
@@ -597,6 +625,16 @@ packages:
       '@ethersproject/bytes': 5.3.0
       '@ethersproject/logger': 5.3.0
       '@ethersproject/properties': 5.3.0
+    dev: false
+
+  /@ethersproject/abstract-signer/5.4.0:
+    resolution: {integrity: sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
     dev: false
 
   /@ethersproject/address/5.3.0:
@@ -609,10 +647,26 @@ packages:
       '@ethersproject/rlp': 5.3.0
     dev: false
 
+  /@ethersproject/address/5.4.0:
+    resolution: {integrity: sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==}
+    dependencies:
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/rlp': 5.4.0
+    dev: false
+
   /@ethersproject/base64/5.3.0:
     resolution: {integrity: sha512-JIqgtOmgKcbc2sjGWTXyXktqUhvFUDte8fPVsAaOrcPiJf6YotNF+nsrOYGC9pbHBEGSuSBp3QR0varkO8JHEw==}
     dependencies:
       '@ethersproject/bytes': 5.3.0
+    dev: false
+
+  /@ethersproject/base64/5.4.0:
+    resolution: {integrity: sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
     dev: false
 
   /@ethersproject/basex/5.3.0:
@@ -620,6 +674,13 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.3.0
       '@ethersproject/properties': 5.3.0
+    dev: false
+
+  /@ethersproject/basex/5.4.0:
+    resolution: {integrity: sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/properties': 5.4.0
     dev: false
 
   /@ethersproject/bignumber/5.3.0:
@@ -630,16 +691,36 @@ packages:
       bn.js: 4.12.0
     dev: false
 
+  /@ethersproject/bignumber/5.4.0:
+    resolution: {integrity: sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      bn.js: 4.12.0
+    dev: false
+
   /@ethersproject/bytes/5.3.0:
     resolution: {integrity: sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==}
     dependencies:
       '@ethersproject/logger': 5.3.0
     dev: false
 
+  /@ethersproject/bytes/5.4.0:
+    resolution: {integrity: sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==}
+    dependencies:
+      '@ethersproject/logger': 5.4.0
+    dev: false
+
   /@ethersproject/constants/5.3.0:
     resolution: {integrity: sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==}
     dependencies:
       '@ethersproject/bignumber': 5.3.0
+    dev: false
+
+  /@ethersproject/constants/5.4.0:
+    resolution: {integrity: sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==}
+    dependencies:
+      '@ethersproject/bignumber': 5.4.0
     dev: false
 
   /@ethersproject/contracts/5.3.0:
@@ -657,6 +738,21 @@ packages:
       '@ethersproject/transactions': 5.3.0
     dev: false
 
+  /@ethersproject/contracts/5.4.0:
+    resolution: {integrity: sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==}
+    dependencies:
+      '@ethersproject/abi': 5.4.0
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+    dev: false
+
   /@ethersproject/hash/5.3.0:
     resolution: {integrity: sha512-gAFZSjUPQ32CIfoKSMtMEQ+IO0kQxqhwz9fCIFt2DtAq2u4pWt8mL9Z5P0r6KkLcQU8LE9FmuPPyd+JvBzmr1w==}
     dependencies:
@@ -668,6 +764,19 @@ packages:
       '@ethersproject/logger': 5.3.0
       '@ethersproject/properties': 5.3.0
       '@ethersproject/strings': 5.3.0
+    dev: false
+
+  /@ethersproject/hash/5.4.0:
+    resolution: {integrity: sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/strings': 5.4.0
     dev: false
 
   /@ethersproject/hdnode/5.3.0:
@@ -685,6 +794,23 @@ packages:
       '@ethersproject/strings': 5.3.0
       '@ethersproject/transactions': 5.3.0
       '@ethersproject/wordlists': 5.3.0
+    dev: false
+
+  /@ethersproject/hdnode/5.4.0:
+    resolution: {integrity: sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/basex': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/pbkdf2': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+      '@ethersproject/signing-key': 5.4.0
+      '@ethersproject/strings': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      '@ethersproject/wordlists': 5.4.0
     dev: false
 
   /@ethersproject/json-wallets/5.3.0:
@@ -705,6 +831,24 @@ packages:
       scrypt-js: 3.0.1
     dev: false
 
+  /@ethersproject/json-wallets/5.4.0:
+    resolution: {integrity: sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/hdnode': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/pbkdf2': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/random': 5.4.0
+      '@ethersproject/strings': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      aes-js: 3.0.0
+      scrypt-js: 3.0.1
+    dev: false
+
   /@ethersproject/keccak256/5.3.0:
     resolution: {integrity: sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==}
     dependencies:
@@ -712,8 +856,19 @@ packages:
       js-sha3: 0.5.7
     dev: false
 
+  /@ethersproject/keccak256/5.4.0:
+    resolution: {integrity: sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      js-sha3: 0.5.7
+    dev: false
+
   /@ethersproject/logger/5.3.0:
     resolution: {integrity: sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA==}
+    dev: false
+
+  /@ethersproject/logger/5.4.0:
+    resolution: {integrity: sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==}
     dev: false
 
   /@ethersproject/networks/5.3.0:
@@ -728,6 +883,12 @@ packages:
       '@ethersproject/logger': 5.3.0
     dev: false
 
+  /@ethersproject/networks/5.4.1:
+    resolution: {integrity: sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==}
+    dependencies:
+      '@ethersproject/logger': 5.4.0
+    dev: false
+
   /@ethersproject/pbkdf2/5.3.0:
     resolution: {integrity: sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==}
     dependencies:
@@ -735,10 +896,23 @@ packages:
       '@ethersproject/sha2': 5.3.0
     dev: false
 
+  /@ethersproject/pbkdf2/5.4.0:
+    resolution: {integrity: sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+    dev: false
+
   /@ethersproject/properties/5.3.0:
     resolution: {integrity: sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==}
     dependencies:
       '@ethersproject/logger': 5.3.0
+    dev: false
+
+  /@ethersproject/properties/5.4.0:
+    resolution: {integrity: sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==}
+    dependencies:
+      '@ethersproject/logger': 5.4.0
     dev: false
 
   /@ethersproject/providers/5.3.0:
@@ -768,26 +942,26 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@ethersproject/providers/5.3.1:
-    resolution: {integrity: sha512-HC63vENTrur6/JKEhcQbA8PRDj1FAesdpX98IW+xAAo3EAkf70ou5fMIA3KCGzJDLNTeYA4C2Bonz849tVLekg==}
+  /@ethersproject/providers/5.4.1:
+    resolution: {integrity: sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==}
     dependencies:
-      '@ethersproject/abstract-provider': 5.3.0
-      '@ethersproject/abstract-signer': 5.3.0
-      '@ethersproject/address': 5.3.0
-      '@ethersproject/basex': 5.3.0
-      '@ethersproject/bignumber': 5.3.0
-      '@ethersproject/bytes': 5.3.0
-      '@ethersproject/constants': 5.3.0
-      '@ethersproject/hash': 5.3.0
-      '@ethersproject/logger': 5.3.0
-      '@ethersproject/networks': 5.3.1
-      '@ethersproject/properties': 5.3.0
-      '@ethersproject/random': 5.3.0
-      '@ethersproject/rlp': 5.3.0
-      '@ethersproject/sha2': 5.3.0
-      '@ethersproject/strings': 5.3.0
-      '@ethersproject/transactions': 5.3.0
-      '@ethersproject/web': 5.3.0
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/basex': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/hash': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/networks': 5.4.1
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/random': 5.4.0
+      '@ethersproject/rlp': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+      '@ethersproject/strings': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      '@ethersproject/web': 5.4.0
       bech32: 1.1.4
       ws: 7.4.6
     transitivePeerDependencies:
@@ -802,11 +976,25 @@ packages:
       '@ethersproject/logger': 5.3.0
     dev: false
 
+  /@ethersproject/random/5.4.0:
+    resolution: {integrity: sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+    dev: false
+
   /@ethersproject/rlp/5.3.0:
     resolution: {integrity: sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==}
     dependencies:
       '@ethersproject/bytes': 5.3.0
       '@ethersproject/logger': 5.3.0
+    dev: false
+
+  /@ethersproject/rlp/5.4.0:
+    resolution: {integrity: sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
     dev: false
 
   /@ethersproject/sha2/5.3.0:
@@ -817,12 +1005,31 @@ packages:
       hash.js: 1.1.7
     dev: false
 
+  /@ethersproject/sha2/5.4.0:
+    resolution: {integrity: sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      hash.js: 1.1.7
+    dev: false
+
   /@ethersproject/signing-key/5.3.0:
     resolution: {integrity: sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==}
     dependencies:
       '@ethersproject/bytes': 5.3.0
       '@ethersproject/logger': 5.3.0
       '@ethersproject/properties': 5.3.0
+      bn.js: 4.12.0
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/signing-key/5.4.0:
+    resolution: {integrity: sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
       bn.js: 4.12.0
       elliptic: 6.5.4
       hash.js: 1.1.7
@@ -838,12 +1045,30 @@ packages:
       '@ethersproject/strings': 5.3.0
     dev: false
 
+  /@ethersproject/solidity/5.4.0:
+    resolution: {integrity: sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==}
+    dependencies:
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+      '@ethersproject/strings': 5.4.0
+    dev: false
+
   /@ethersproject/strings/5.3.0:
     resolution: {integrity: sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==}
     dependencies:
       '@ethersproject/bytes': 5.3.0
       '@ethersproject/constants': 5.3.0
       '@ethersproject/logger': 5.3.0
+    dev: false
+
+  /@ethersproject/strings/5.4.0:
+    resolution: {integrity: sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/logger': 5.4.0
     dev: false
 
   /@ethersproject/transactions/5.3.0:
@@ -860,12 +1085,34 @@ packages:
       '@ethersproject/signing-key': 5.3.0
     dev: false
 
+  /@ethersproject/transactions/5.4.0:
+    resolution: {integrity: sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==}
+    dependencies:
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/rlp': 5.4.0
+      '@ethersproject/signing-key': 5.4.0
+    dev: false
+
   /@ethersproject/units/5.3.0:
     resolution: {integrity: sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==}
     dependencies:
       '@ethersproject/bignumber': 5.3.0
       '@ethersproject/constants': 5.3.0
       '@ethersproject/logger': 5.3.0
+    dev: false
+
+  /@ethersproject/units/5.4.0:
+    resolution: {integrity: sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==}
+    dependencies:
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/logger': 5.4.0
     dev: false
 
   /@ethersproject/wallet/5.3.0:
@@ -888,6 +1135,26 @@ packages:
       '@ethersproject/wordlists': 5.3.0
     dev: false
 
+  /@ethersproject/wallet/5.4.0:
+    resolution: {integrity: sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/hash': 5.4.0
+      '@ethersproject/hdnode': 5.4.0
+      '@ethersproject/json-wallets': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/random': 5.4.0
+      '@ethersproject/signing-key': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      '@ethersproject/wordlists': 5.4.0
+    dev: false
+
   /@ethersproject/web/5.3.0:
     resolution: {integrity: sha512-Ni6/DHnY6k/TD41LEkv0RQDx4jqWz5e/RZvrSecsxGYycF+MFy2z++T/yGc2peRunLOTIFwEksgEGGlbwfYmhQ==}
     dependencies:
@@ -898,6 +1165,16 @@ packages:
       '@ethersproject/strings': 5.3.0
     dev: false
 
+  /@ethersproject/web/5.4.0:
+    resolution: {integrity: sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==}
+    dependencies:
+      '@ethersproject/base64': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/strings': 5.4.0
+    dev: false
+
   /@ethersproject/wordlists/5.3.0:
     resolution: {integrity: sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==}
     dependencies:
@@ -906,6 +1183,16 @@ packages:
       '@ethersproject/logger': 5.3.0
       '@ethersproject/properties': 5.3.0
       '@ethersproject/strings': 5.3.0
+    dev: false
+
+  /@ethersproject/wordlists/5.4.0:
+    resolution: {integrity: sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==}
+    dependencies:
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/hash': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/strings': 5.4.0
     dev: false
 
   /@hapi/hoek/9.2.0:
@@ -1148,32 +1435,6 @@ packages:
       bull: 3.22.9
     dev: false
 
-  /@nestjs/common/7.6.17_749adfffee5e19d8e7e0c57e9f416d16:
-    resolution: {integrity: sha512-RHvD32FxfV7yDWX9GPmn0ZSv7ka5kLeVamU5ZpoXSTUjkGqWFt3MTyIP+HUQD2778kDqT+CgEtVJ1fxDG5Oh9g==}
-    peerDependencies:
-      cache-manager: '*'
-      class-transformer: '*'
-      class-validator: '*'
-      reflect-metadata: ^0.1.12
-      rxjs: ^6.0.0
-    peerDependenciesMeta:
-      cache-manager:
-        optional: true
-      class-transformer:
-        optional: true
-      class-validator:
-        optional: true
-    dependencies:
-      axios: 0.21.1
-      class-validator: 0.13.1
-      iterare: 1.2.1
-      rxjs: 6.6.7
-      tslib: 2.2.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@nestjs/common/7.6.18:
     resolution: {integrity: sha512-BUJQHNhWzwWOkS4Ryndzd4HTeRObcAWV2Fh+ermyo3q3xYQQzNoEWclJVL/wZec8AONELwIJ+PSpWI53VP0leg==}
     peerDependencies:
@@ -1198,14 +1459,40 @@ packages:
       - debug
     dev: false
 
-  /@nestjs/config/0.6.3_@nestjs+common@7.6.17+rxjs@6.6.7:
+  /@nestjs/common/7.6.18_749adfffee5e19d8e7e0c57e9f416d16:
+    resolution: {integrity: sha512-BUJQHNhWzwWOkS4Ryndzd4HTeRObcAWV2Fh+ermyo3q3xYQQzNoEWclJVL/wZec8AONELwIJ+PSpWI53VP0leg==}
+    peerDependencies:
+      cache-manager: '*'
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12
+      rxjs: ^6.0.0
+    peerDependenciesMeta:
+      cache-manager:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      axios: 0.21.1
+      class-validator: 0.13.1
+      iterare: 1.2.1
+      rxjs: 6.6.7
+      tslib: 2.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@nestjs/config/0.6.3_@nestjs+common@7.6.18+rxjs@6.6.7:
     resolution: {integrity: sha512-JxvvUpmH0/WOrTB+zh8dEkxSUQXhB7V3d/qeQXyCnMiEFjaq89+fNFztpWjz4DlOfdS4/eYTzIEy9PH2uGnfzA==}
     peerDependencies:
       '@nestjs/common': ^6.10.0 || ^7.0.0
       reflect-metadata: ^0.1.12
       rxjs: ^6.0.0
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
       lodash.get: 4.4.2
@@ -1215,8 +1502,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@nestjs/core/7.6.17_6de30afcac7c20e6f05d126d96a4edb6:
-    resolution: {integrity: sha512-dH7PGDj1dvBfOYgxJlxh54vdnFFSLst7+Spg3E7Jpo+n11Ht5Ee5mTjSzXieRVfFba/sI3NIHF/N1stn36bU9w==}
+  /@nestjs/core/7.6.18_ab65c85c0c76e548e0bb97a3daab8f73:
+    resolution: {integrity: sha512-CGu20OjIxgFDY7RJT5t1TDGL8wSlTSlbZEkn8U5OlICZEB3WIpi98G7ajJpnRWmEgW8S4aDJmRKGjT+Ntj5U4A==}
     requiresBuild: true
     peerDependencies:
       '@nestjs/common': ^7.0.0
@@ -1233,7 +1520,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
       '@nestjs/platform-express': 7.6.18_2664420588e0901c7943acb4693cbaf4
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.0.7
@@ -1286,7 +1573,7 @@ packages:
       '@nestjs/core': 7.6.18_e6f0514ea3d89219387f66417a78dd96
     dev: false
 
-  /@nestjs/cqrs/7.0.1_e8830d008f1c8c5b585245e04815667a:
+  /@nestjs/cqrs/7.0.1_31f45c01bada0af28c4fa5d0ce49c429:
     resolution: {integrity: sha512-4UJAH3ryJvT+SDeuB5ls1OpJsPr3xqsyiuWCfVd1oyzCLazuxl04t/xup005HtWdxczwLgaAau7SIAb+XZotBQ==}
     peerDependencies:
       '@nestjs/common': ^6.0.0 || ^7.0.0
@@ -1294,31 +1581,21 @@ packages:
       reflect-metadata: 0.1.13
       rxjs: ^6.4.0
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
       rxjs: 6.6.7
     dev: false
 
-  /@nestjs/mapped-types/0.4.0_2e33f39e6e78d27a0f8774b7c192db08:
-    resolution: {integrity: sha512-TVtd/aTb7EqPhVczdeuvzF9dY0fyE3ivvCstc2eO+AkNqrfzSG1kXYYiUUznKjd0qDa8g2TmPSmHUQ21AXsV1Q==}
+  /@nestjs/mapped-types/0.4.1_7641413de8fbaf461307498425c3ccb9:
+    resolution: {integrity: sha512-JXrw2LMangSU3vnaXWXVX47GRG1FbbNh4aVBbidDjxT3zlghsoNQY6qyWtT001MCl8lJGo8I6i6+DurBRRxl/Q==}
     peerDependencies:
       '@nestjs/common': ^7.0.8
       class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0
       class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0
       reflect-metadata: ^0.1.12
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
       class-validator: 0.13.1
-    dev: false
-
-  /@nestjs/passport/7.1.5_6b9aabeef2ebcf8aef3549ea590af16a:
-    resolution: {integrity: sha512-Hu9hPxTdBZA0C4GrWTsSflzwsJ99oAk9jqAwpcszdFNqfjMjkPGuCM9QsVZbBP2bE8fxrVrPsNOILS6puY8e/A==}
-    peerDependencies:
-      '@nestjs/common': ^6.0.0 || ^7.0.0
-      passport: ^0.4.0
-    dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      passport: 0.4.1
     dev: false
 
   /@nestjs/passport/7.1.5_fd45a09fcff1f973814c588ad08d33e0:
@@ -1328,6 +1605,16 @@ packages:
       passport: ^0.4.0
     dependencies:
       '@nestjs/common': 7.6.18
+      passport: 0.4.1
+    dev: false
+
+  /@nestjs/passport/7.1.6_fd45a09fcff1f973814c588ad08d33e0:
+    resolution: {integrity: sha512-iHD/4D01CsKKWg7kUzo4yGNS4m90z1an0eUz+6nBlE5VeEOuCzhGFoBKAt0OKLJLOTEsJKuj4C2b5QfjqXVTyQ==}
+    peerDependencies:
+      '@nestjs/common': ^6.0.0 || ^7.0.0
+      passport: ^0.4.0
+    dependencies:
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
       passport: 0.4.1
     dev: false
 
@@ -1346,19 +1633,19 @@ packages:
       tslib: 2.2.0
     dev: false
 
-  /@nestjs/schedule/0.4.3_@nestjs+common@7.6.17:
+  /@nestjs/schedule/0.4.3_@nestjs+common@7.6.18:
     resolution: {integrity: sha512-EowkpwD09lrdMFzjt/kNQgaq6MG0GrNadNoOEebbfyA0qBU0UTg7J+FVullTR9+5HtaegqqAuWDvZlVoGHYz+Q==}
     peerDependencies:
       '@nestjs/common': ^6.10.11 || ^7.0.0
       reflect-metadata: ^0.1.12
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
       cron: 1.7.2
       uuid: 8.3.2
     dev: false
 
-  /@nestjs/swagger/4.8.0_f5f7353216d93413c7498d2c55f68a84:
-    resolution: {integrity: sha512-YU+ahCOoOTZwSHrODHBiQDCqi7GWEjmSFg3Tot/lwVuQ321/3fIOz/lf+ehVQ5DFr7nVMhB7BRWFJLtE/+NhqQ==}
+  /@nestjs/swagger/4.8.2_74f4554e640a8c7b6751d53d8346c01a:
+    resolution: {integrity: sha512-RSUwcVxrzXF7/b/IZ5lXnYHJ6jIGS9wWRTJKIt1kIaCNWT+0wRfTlAyhQkzs2g35/PTXJEcdIwwY7mBO/bwHzw==}
     peerDependencies:
       '@nestjs/common': ^6.8.0 || ^7.0.0
       '@nestjs/core': ^6.8.0 || ^7.0.0
@@ -1371,9 +1658,9 @@ packages:
       swagger-ui-express:
         optional: true
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
-      '@nestjs/mapped-types': 0.4.0_2e33f39e6e78d27a0f8774b7c192db08
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
+      '@nestjs/mapped-types': 0.4.1_7641413de8fbaf461307498425c3ccb9
       lodash: 4.17.21
       path-to-regexp: 3.2.0
       swagger-ui-express: 4.1.6
@@ -1382,8 +1669,8 @@ packages:
       - class-validator
     dev: false
 
-  /@nestjs/swagger/4.8.0_f9100682edd43d2074cb46854e706969:
-    resolution: {integrity: sha512-YU+ahCOoOTZwSHrODHBiQDCqi7GWEjmSFg3Tot/lwVuQ321/3fIOz/lf+ehVQ5DFr7nVMhB7BRWFJLtE/+NhqQ==}
+  /@nestjs/swagger/4.8.2_bbb437c2acc4c4104a11b39098b7f11a:
+    resolution: {integrity: sha512-RSUwcVxrzXF7/b/IZ5lXnYHJ6jIGS9wWRTJKIt1kIaCNWT+0wRfTlAyhQkzs2g35/PTXJEcdIwwY7mBO/bwHzw==}
     peerDependencies:
       '@nestjs/common': ^6.8.0 || ^7.0.0
       '@nestjs/core': ^6.8.0 || ^7.0.0
@@ -1396,9 +1683,9 @@ packages:
       swagger-ui-express:
         optional: true
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
-      '@nestjs/mapped-types': 0.4.0_2e33f39e6e78d27a0f8774b7c192db08
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
+      '@nestjs/mapped-types': 0.4.1_7641413de8fbaf461307498425c3ccb9
       lodash: 4.17.21
       path-to-regexp: 3.2.0
     transitivePeerDependencies:
@@ -1441,7 +1728,7 @@ packages:
       uuid: 8.3.1
     dev: false
 
-  /@nestjs/typeorm/7.1.5_df95866fd57fe3c3af7787015f39999a:
+  /@nestjs/typeorm/7.1.5_c9af0b2f72f65b72c7522ad6634c8b35:
     resolution: {integrity: sha512-utE1FkYM/gyCXUqw3zKYYS0YZ3DfkAnzsCx4T48cNnSDTCeWS+u3yt0FMDFjwSiQSaLrzpiSff/FaxJQvRlYow==}
     peerDependencies:
       '@nestjs/common': ^6.7.0 || ^7.0.0
@@ -1450,8 +1737,8 @@ packages:
       rxjs: ^6.0.0
       typeorm: ^0.2.7
     dependencies:
-      '@nestjs/common': 7.6.17_749adfffee5e19d8e7e0c57e9f416d16
-      '@nestjs/core': 7.6.17_6de30afcac7c20e6f05d126d96a4edb6
+      '@nestjs/common': 7.6.18_749adfffee5e19d8e7e0c57e9f416d16
+      '@nestjs/core': 7.6.18_ab65c85c0c76e548e0bb97a3daab8f73
       rxjs: 6.6.7
       typeorm: 0.2.34
       uuid: 8.3.1
@@ -2763,34 +3050,34 @@ packages:
   /ethers/5.0.7:
     resolution: {integrity: sha512-1Zu9s+z4BgsDAZcGIYACJdWBB6mVtCCmUonj68Njul7STcSdgwOyj0sCAxCUr2Nsmsamckr4E12q3ecvZPGAUw==}
     dependencies:
-      '@ethersproject/abi': 5.3.1
-      '@ethersproject/abstract-provider': 5.3.0
-      '@ethersproject/abstract-signer': 5.3.0
-      '@ethersproject/address': 5.3.0
-      '@ethersproject/base64': 5.3.0
-      '@ethersproject/bignumber': 5.3.0
-      '@ethersproject/bytes': 5.3.0
-      '@ethersproject/constants': 5.3.0
-      '@ethersproject/contracts': 5.3.0
-      '@ethersproject/hash': 5.3.0
+      '@ethersproject/abi': 5.4.0
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/base64': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/contracts': 5.4.0
+      '@ethersproject/hash': 5.4.0
       '@ethersproject/hdnode': 5.3.0
       '@ethersproject/json-wallets': 5.3.0
-      '@ethersproject/keccak256': 5.3.0
-      '@ethersproject/logger': 5.3.0
-      '@ethersproject/networks': 5.3.1
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/networks': 5.4.1
       '@ethersproject/pbkdf2': 5.3.0
-      '@ethersproject/properties': 5.3.0
-      '@ethersproject/providers': 5.3.1
-      '@ethersproject/random': 5.3.0
-      '@ethersproject/rlp': 5.3.0
-      '@ethersproject/sha2': 5.3.0
-      '@ethersproject/signing-key': 5.3.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/providers': 5.4.1
+      '@ethersproject/random': 5.4.0
+      '@ethersproject/rlp': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+      '@ethersproject/signing-key': 5.4.0
       '@ethersproject/solidity': 5.3.0
-      '@ethersproject/strings': 5.3.0
-      '@ethersproject/transactions': 5.3.0
+      '@ethersproject/strings': 5.4.0
+      '@ethersproject/transactions': 5.4.0
       '@ethersproject/units': 5.3.0
       '@ethersproject/wallet': 5.3.0
-      '@ethersproject/web': 5.3.0
+      '@ethersproject/web': 5.4.0
       '@ethersproject/wordlists': 5.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -2830,6 +3117,44 @@ packages:
       '@ethersproject/wallet': 5.3.0
       '@ethersproject/web': 5.3.0
       '@ethersproject/wordlists': 5.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /ethers/5.4.1:
+    resolution: {integrity: sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==}
+    dependencies:
+      '@ethersproject/abi': 5.4.0
+      '@ethersproject/abstract-provider': 5.4.0
+      '@ethersproject/abstract-signer': 5.4.0
+      '@ethersproject/address': 5.4.0
+      '@ethersproject/base64': 5.4.0
+      '@ethersproject/basex': 5.4.0
+      '@ethersproject/bignumber': 5.4.0
+      '@ethersproject/bytes': 5.4.0
+      '@ethersproject/constants': 5.4.0
+      '@ethersproject/contracts': 5.4.0
+      '@ethersproject/hash': 5.4.0
+      '@ethersproject/hdnode': 5.4.0
+      '@ethersproject/json-wallets': 5.4.0
+      '@ethersproject/keccak256': 5.4.0
+      '@ethersproject/logger': 5.4.0
+      '@ethersproject/networks': 5.4.1
+      '@ethersproject/pbkdf2': 5.4.0
+      '@ethersproject/properties': 5.4.0
+      '@ethersproject/providers': 5.4.1
+      '@ethersproject/random': 5.4.0
+      '@ethersproject/rlp': 5.4.0
+      '@ethersproject/sha2': 5.4.0
+      '@ethersproject/signing-key': 5.4.0
+      '@ethersproject/solidity': 5.4.0
+      '@ethersproject/strings': 5.4.0
+      '@ethersproject/transactions': 5.4.0
+      '@ethersproject/units': 5.4.0
+      '@ethersproject/wallet': 5.4.0
+      '@ethersproject/web': 5.4.0
+      '@ethersproject/wordlists': 5.4.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5924,14 +6249,14 @@ packages:
     dev: false
 
   file:projects/origin-247-certificate.tgz:
-    resolution: {integrity: sha512-m7GbdM7bSUOqEnn/mPbFFJ9+WH3VRk4QWXesi5HLGh8EYPgkBO4oUUhuxd7KqvCEdJ3kdxLzCg/9ut2Y23kM3w==, tarball: file:projects/origin-247-certificate.tgz}
+    resolution: {integrity: sha512-8qq1NafbElrMhhjG2ejHzALNIxe/pUN5adlBynckBFl/HZNQNyESkbj5i7dhv2a87HzZ1OSjjMWez+kpvfCGvA==, tarball: file:projects/origin-247-certificate.tgz}
     name: '@rush-temp/origin-247-certificate'
     version: 0.0.0
     dependencies:
-      '@energyweb/issuer': 3.2.1-alpha.1623138698.0
-      '@energyweb/issuer-api': 0.2.1-alpha.1623138698.0_84d2e8496da2b35f72ec1aae830fb752
-      '@energyweb/origin-backend-utils': 1.5.2-alpha.1623138698.0_@nestjs+platform-express@7.6.18
-      '@energyweb/utils-general': 11.0.3-alpha.1623138698.0
+      '@energyweb/issuer': 3.2.1-alpha.1625573089.0
+      '@energyweb/issuer-api': 0.2.1-alpha.1625573089.0_84d2e8496da2b35f72ec1aae830fb752
+      '@energyweb/origin-backend-utils': 1.5.2-alpha.1625573089.0_@nestjs+platform-express@7.6.18
+      '@energyweb/utils-general': 11.0.3-alpha.1625573089.0
       '@nestjs/bull': 0.3.1_c86fa2ed7bc9e7a48760c2e5795b24d0
       '@nestjs/common': 7.6.18
       '@nestjs/core': 7.6.18_e6f0514ea3d89219387f66417a78dd96

--- a/packages/origin-247-certificate/README.md
+++ b/packages/origin-247-certificate/README.md
@@ -55,7 +55,7 @@ export class SomeModule {}
 Use the service:
 
 ```ts
-import { CertificateService } from '@energyweb/origin-247-certificate';
+import { CertificateService, CERTIFICATE_SERVICE_TOKEN } from '@energyweb/origin-247-certificate';
 
 /**
  * Because certificate entity allows to store custom data called "metadata"
@@ -69,6 +69,7 @@ interface IMetadata {
 
 export class SomeService {
   constructor(
+    @Inject(CERTIFICATE_SERVICE_TOKEN)
     private certificateService: CertificateService<IMetadata>
   ) {}
 

--- a/packages/origin-247-certificate/package.json
+++ b/packages/origin-247-certificate/package.json
@@ -17,10 +17,10 @@
         "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes"
     },
     "dependencies": {
-        "@energyweb/issuer": "3.2.1-alpha.1623138698.0",
-        "@energyweb/issuer-api": "0.2.1-alpha.1623138698.0",
-        "@energyweb/origin-backend-utils": "1.5.2-alpha.1623138698.0",
-        "@energyweb/utils-general": "11.0.3-alpha.1623138698.0",
+        "@energyweb/issuer": "3.2.1-alpha.1625573089.0",
+        "@energyweb/issuer-api": "0.2.1-alpha.1625573089.0",
+        "@energyweb/origin-backend-utils": "1.5.2-alpha.1625573089.0",
+        "@energyweb/utils-general": "11.0.3-alpha.1625573089.0",
         "@nestjs/bull": "0.3.1",
         "@nestjs/common": "7.6.18",
         "@nestjs/core": "7.6.18",

--- a/packages/origin-247-certificate/src/certificate.module.ts
+++ b/packages/origin-247-certificate/src/certificate.module.ts
@@ -5,10 +5,16 @@ import { CertificateModule as IssuerCertificateModule } from '@energyweb/issuer-
 
 import { CertificateService } from './certificate.service';
 import { BlockchainActionsProcessor } from './blockchain-actions.processor';
+import { CERTIFICATE_SERVICE_TOKEN } from './types';
+
+const serviceProvider = {
+    provide: CERTIFICATE_SERVICE_TOKEN,
+    useClass: CertificateService
+};
 
 @Module({
-    providers: [CertificateService, BlockchainActionsProcessor],
-    exports: [CertificateService],
+    providers: [serviceProvider, BlockchainActionsProcessor],
+    exports: [serviceProvider],
     imports: [
         IssuerCertificateModule,
         CqrsModule,

--- a/packages/origin-247-certificate/src/certificateForUnitTests.module.ts
+++ b/packages/origin-247-certificate/src/certificateForUnitTests.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+
+import { CertificateForUnitTestsService } from './certificateForUnitTests.service';
+import { CERTIFICATE_SERVICE_TOKEN } from './types';
+
+const serviceProvider = {
+    provide: CERTIFICATE_SERVICE_TOKEN,
+    useClass: CertificateForUnitTestsService
+};
+
+@Module({
+    providers: [serviceProvider],
+    exports: [serviceProvider],
+    imports: [CqrsModule]
+})
+export class CertificateForUnitTestsModule {}

--- a/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
+++ b/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
@@ -1,0 +1,120 @@
+import { CertificateService } from './certificate.service';
+import { EventBus } from '@nestjs/cqrs';
+import {
+    ICertificate,
+    IClaimCommand,
+    ITransferCommand,
+    ISuccessResponse,
+    IIssuedCertificate,
+    IIssueCommandParams
+} from './types';
+import { Injectable } from '@nestjs/common';
+import { CertificatePersistedEvent } from './externals';
+
+type PublicPart<T> = { [K in keyof T]: T[K] };
+
+@Injectable()
+export class CertificateForUnitTestsService<T> implements PublicPart<CertificateService<T>> {
+    private serial = 0;
+    private db: ICertificate<T>[] = [];
+
+    constructor(private readonly eventBus: EventBus) {}
+
+    public async getAll(): Promise<ICertificate<T>[]> {
+        return [...this.db];
+    }
+
+    public async getById(id: number): Promise<ICertificate<T> | null> {
+        return this.db.find((c) => c.id === id) ?? null;
+    }
+
+    public async issue(params: IIssueCommandParams<T>): Promise<IIssuedCertificate<T>> {
+        this.serial += 1;
+
+        const certificate: ICertificate<T> = {
+            claims: [],
+            claimers: {},
+            creationBlockHash: '',
+            creationTime: Math.floor(Date.now() / 1000),
+            deviceId: params.deviceId,
+            generationStartTime: Math.floor(params.toTime.getTime() / 1000),
+            generationEndTime: Math.floor(params.toTime.getTime() / 1000),
+            id: this.serial,
+            tokenId: this.serial,
+            issuedPrivately: false,
+            metadata: params.metadata,
+            owners: {
+                [params.toAddress]: params.energyValue
+            }
+        };
+
+        this.db.push(certificate);
+
+        setTimeout(() => {
+            this.eventBus.publish(new CertificatePersistedEvent(certificate.id));
+        }, 2000);
+
+        return {
+            ...certificate,
+            issuedPrivately: false,
+            isClaimed: false,
+            isOwned: true,
+            myClaims: [],
+            energy: {
+                claimedVolume: '0',
+                privateVolume: '0',
+                publicVolume: params.energyValue
+            }
+        };
+    }
+
+    public async claim(command: IClaimCommand): Promise<ISuccessResponse> {
+        const certificate = this.db.find((c) => c.id === command.certificateId);
+
+        if (!certificate) {
+            return {
+                success: false,
+                message: `No certificate of ${command.certificateId} found`
+            };
+        }
+
+        certificate.claims.push({
+            claimData: command.claimData,
+            value:
+                Number(command.energyValue) ??
+                Object.values(certificate.owners).reduce((sum, v) => (sum += Number(v)), 0),
+            topic: 0,
+            from: '',
+            id: 0,
+            to: ''
+        });
+
+        return {
+            success: true
+        };
+    }
+
+    public async transfer(command: ITransferCommand): Promise<ISuccessResponse> {
+        const certificate = this.db.find((c) => c.id === command.certificateId);
+
+        if (!certificate) {
+            return {
+                success: false,
+                message: `No certificate of ${command.certificateId} found`
+            };
+        }
+
+        const value = Number(command.energyValue ?? certificate.owners[command.fromAddress]);
+
+        certificate.owners[command.fromAddress] = (
+            Number(certificate.owners[command.fromAddress]) - value
+        ).toString();
+        certificate.owners[command.toAddress] = (
+            Number(certificate.owners[command.toAddress] ?? 0) + value
+        ).toString();
+
+        return {
+            success: true
+        };
+    }
+}

--- a/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
+++ b/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
@@ -41,7 +41,6 @@ export class CertificateForUnitTestsService<T> implements PublicPart<Certificate
             generationStartTime: Math.floor(params.fromTime.getTime() / 1000),
             generationEndTime: Math.floor(params.toTime.getTime() / 1000),
             id: this.serial,
-            tokenId: this.serial,
             issuedPrivately: false,
             metadata: params.metadata,
             owners: {

--- a/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
+++ b/packages/origin-247-certificate/src/certificateForUnitTests.service.ts
@@ -1,5 +1,6 @@
 import { CertificateService } from './certificate.service';
 import { EventBus } from '@nestjs/cqrs';
+import { BigNumber } from 'ethers';
 import {
     ICertificate,
     IClaimCommand,
@@ -37,7 +38,7 @@ export class CertificateForUnitTestsService<T> implements PublicPart<Certificate
             creationBlockHash: '',
             creationTime: Math.floor(Date.now() / 1000),
             deviceId: params.deviceId,
-            generationStartTime: Math.floor(params.toTime.getTime() / 1000),
+            generationStartTime: Math.floor(params.fromTime.getTime() / 1000),
             generationEndTime: Math.floor(params.toTime.getTime() / 1000),
             id: this.serial,
             tokenId: this.serial,
@@ -81,9 +82,11 @@ export class CertificateForUnitTestsService<T> implements PublicPart<Certificate
         certificate.claims.push({
             claimData: command.claimData,
             value:
-                Number(command.energyValue) ??
-                Object.values(certificate.owners).reduce((sum, v) => (sum += Number(v)), 0),
-            topic: 0,
+                command.energyValue ??
+                Object.values(certificate.owners)
+                    .reduce((sum, v) => sum.add(v), BigNumber.from(0))
+                    .toString(),
+            topic: '0',
             from: '',
             id: 0,
             to: ''

--- a/packages/origin-247-certificate/src/externals.ts
+++ b/packages/origin-247-certificate/src/externals.ts
@@ -1,0 +1,1 @@
+export { CertificatePersistedEvent } from '@energyweb/issuer-api';

--- a/packages/origin-247-certificate/src/index.ts
+++ b/packages/origin-247-certificate/src/index.ts
@@ -3,3 +3,5 @@ export * from './types';
 export * from './certificate.service';
 export * from './blockchain-actions.processor';
 export * from './externals';
+export * from './certificateForUnitTests.module';
+export * from './certificateForUnitTests.service';

--- a/packages/origin-247-certificate/src/index.ts
+++ b/packages/origin-247-certificate/src/index.ts
@@ -2,3 +2,4 @@ export * from './certificate.module';
 export * from './types';
 export * from './certificate.service';
 export * from './blockchain-actions.processor';
+export * from './externals';

--- a/packages/origin-247-certificate/src/types.ts
+++ b/packages/origin-247-certificate/src/types.ts
@@ -89,3 +89,5 @@ export type BlockchainAction =
     | IAction<BlockchainActionType.Issuance, IIssueCommand<any>>
     | IAction<BlockchainActionType.Transfer, ITransferCommand>
     | IAction<BlockchainActionType.Claim, IClaimCommand>;
+
+export const CERTIFICATE_SERVICE_TOKEN = Symbol.for('CERTIFICATE_SERVICE_TOKEN');

--- a/packages/origin-247-certificate/src/types.ts
+++ b/packages/origin-247-certificate/src/types.ts
@@ -11,7 +11,6 @@ export interface ICertificate<T = null> {
     owners: Record<string, string>;
     claimers: Record<string, string> | null;
     claims: IClaim[];
-    tokenId: number;
     creationBlockHash: string;
     issuedPrivately: boolean;
     metadata: T;
@@ -19,7 +18,6 @@ export interface ICertificate<T = null> {
 
 export interface IIssuedCertificate<T = null> {
     id: number;
-    tokenId: number;
     deviceId: string;
     generationStartTime: number;
     generationEndTime: number;

--- a/packages/origin-247-certificate/test/setup.ts
+++ b/packages/origin-247-certificate/test/setup.ts
@@ -6,7 +6,7 @@ import { BullModule } from '@nestjs/bull';
 import { getProviderWithFallback } from '@energyweb/utils-general';
 import { Test } from '@nestjs/testing';
 import { DatabaseService } from '@energyweb/origin-backend-utils';
-import { CertificateModule, CertificateService } from '../src';
+import { CertificateModule, CertificateService, CERTIFICATE_SERVICE_TOKEN } from '../src';
 import { entities as IssuerEntities } from '@energyweb/issuer-api';
 import { PassportModule } from '@nestjs/passport';
 
@@ -71,7 +71,7 @@ export const bootstrapTestInstance: any = async () => {
 
     const app = moduleFixture.createNestApplication();
 
-    const certificateService = await app.resolve<CertificateService>(CertificateService);
+    const certificateService = await app.resolve<CertificateService>(CERTIFICATE_SERVICE_TOKEN);
     const databaseService = await app.resolve<DatabaseService>(DatabaseService);
     const blockchainPropertiesService = await app.resolve<BlockchainPropertiesService>(
         BlockchainPropertiesService


### PR DESCRIPTION
So because I wanted to test origin-247-transfer module using only unit tests (without running blockchain and database) I needed CertificateModule to expose it's "forUnitTests" implementation, which is working in-memory instead on real data.

Let's keep this open for now, because I may add some slightly adjustments here when I work over that