### PR TITLE
feat(origin-247-claim): add spreadMatcher

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.3
 specifiers:
   '@energyweb/issuer': 3.2.1-alpha.1625651017.0
   '@energyweb/issuer-api': 0.2.1-alpha.1625651017.0
-  '@energyweb/origin-247-certificate': ^0.0.2-alpha.1626083770.0
   '@energyweb/origin-backend-utils': 1.5.2-alpha.1625651017.0
   '@energyweb/utils-general': 11.0.3-alpha.1625651017.0
   '@nestjs/bull': 0.3.1
@@ -15,6 +14,7 @@ specifiers:
   '@nestjs/testing': 7.6.18
   '@nestjs/typeorm': 7.1.5
   '@rush-temp/origin-247-certificate': file:./projects/origin-247-certificate.tgz
+  '@rush-temp/origin-247-claim': file:./projects/origin-247-claim.tgz
   '@rush-temp/origin-247-transfer': file:./projects/origin-247-transfer.tgz
   '@types/bull': 3.15.1
   '@types/jest': 26.0.23
@@ -39,7 +39,6 @@ specifiers:
 dependencies:
   '@energyweb/issuer': 3.2.1-alpha.1625651017.0
   '@energyweb/issuer-api': 0.2.1-alpha.1625651017.0_eb9935bd4f97b23ab8881eee244eb1f7
-  '@energyweb/origin-247-certificate': 0.0.2-alpha.1626084321.0_037dc7b7d2399f4623ff58161b27e748
   '@energyweb/origin-backend-utils': 1.5.2-alpha.1625651017.0_037dc7b7d2399f4623ff58161b27e748
   '@energyweb/utils-general': 11.0.3-alpha.1625651017.0
   '@nestjs/bull': 0.3.1_c86fa2ed7bc9e7a48760c2e5795b24d0
@@ -51,6 +50,7 @@ dependencies:
   '@nestjs/testing': 7.6.18_9cd0f963ae6f35bf288217e4f1c45cb4
   '@nestjs/typeorm': 7.1.5_476bd709bf4288b37cfeb220ce38756a
   '@rush-temp/origin-247-certificate': file:projects/origin-247-certificate.tgz_d6b54fd4eaabebb097645626555e6c09
+  '@rush-temp/origin-247-claim': file:projects/origin-247-claim.tgz_passport@0.4.1
   '@rush-temp/origin-247-transfer': file:projects/origin-247-transfer.tgz_passport@0.4.1
   '@types/bull': 3.15.1
   '@types/jest': 26.0.23
@@ -6034,8 +6034,63 @@ packages:
       - utf-8-validate
     dev: false
 
+  file:projects/origin-247-claim.tgz_passport@0.4.1:
+    resolution: {integrity: sha512-GUAELWD4jUbMnnzBLM83YmmKcTbTiZR56WFhY/O4D1+/ckD64a/KYK2058XUhL122nWLnl3Oyi02vaj4zQJsrg==, tarball: file:projects/origin-247-claim.tgz}
+    id: file:projects/origin-247-claim.tgz
+    name: '@rush-temp/origin-247-claim'
+    version: 0.0.0
+    dependencies:
+      '@energyweb/issuer': 3.2.1-alpha.1625651017.0
+      '@energyweb/issuer-api': 0.2.1-alpha.1625651017.0_eb9935bd4f97b23ab8881eee244eb1f7
+      '@energyweb/origin-backend-utils': 1.5.2-alpha.1625651017.0_037dc7b7d2399f4623ff58161b27e748
+      '@energyweb/utils-general': 11.0.3-alpha.1625651017.0
+      '@nestjs/bull': 0.3.1_c86fa2ed7bc9e7a48760c2e5795b24d0
+      '@nestjs/common': 7.6.18_class-transformer@0.4.0
+      '@nestjs/core': 7.6.18_e6f0514ea3d89219387f66417a78dd96
+      '@nestjs/cqrs': 7.0.1_2664420588e0901c7943acb4693cbaf4
+      '@nestjs/passport': 7.1.5_fd45a09fcff1f973814c588ad08d33e0
+      '@nestjs/platform-express': 7.6.18_2664420588e0901c7943acb4693cbaf4
+      '@nestjs/testing': 7.6.18_9cd0f963ae6f35bf288217e4f1c45cb4
+      '@nestjs/typeorm': 7.1.5_476bd709bf4288b37cfeb220ce38756a
+      '@types/jest': 26.0.23
+      '@types/lodash': 4.14.171
+      '@types/node': 15.12.4
+      bull: 3.22.9
+      class-transformer: 0.4.0
+      concurrently: 6.2.0
+      ethers: 5.4.1
+      ganache-cli: 6.12.2
+      jest: 27.0.5_ts-node@9.1.1
+      lodash: 4.17.21
+      pg: 8.6.0
+      ts-jest: 27.0.3_jest@27.0.5+typescript@4.3.4
+      ts-node: 9.1.1_typescript@4.3.4
+      tsconfig-paths: 3.10.1
+      typeorm: 0.2.34
+      typescript: 4.3.4
+      wait-on: 5.3.0
+    transitivePeerDependencies:
+      - '@nestjs/microservices'
+      - '@nestjs/websockets'
+      - bufferutil
+      - cache-manager
+      - canvas
+      - class-validator
+      - debug
+      - express
+      - fastify-swagger
+      - node-notifier
+      - passport
+      - pg-native
+      - reflect-metadata
+      - rxjs
+      - supports-color
+      - swagger-ui-express
+      - utf-8-validate
+    dev: false
+
   file:projects/origin-247-transfer.tgz_passport@0.4.1:
-    resolution: {integrity: sha512-KU8Fs7p70U0Aray7AVPBLIuU3kpOxftX+ZxG+wMMblwqQlpfqfOTjJ2Uq/o2KySkhvaD5zNRAOGDz5H2dg64lQ==, tarball: file:projects/origin-247-transfer.tgz}
+    resolution: {integrity: sha512-WcS9Eq2h2CKRa83/5iNU4SfZT2847J5xMyOKrkC6vkDc2Uj8D9UZ2oLgFZIsMFeo1E58k+RmfATA7wkABH+hjA==, tarball: file:projects/origin-247-transfer.tgz}
     id: file:projects/origin-247-transfer.tgz
     name: '@rush-temp/origin-247-transfer'
     version: 0.0.0

--- a/packages/origin-247-claim/.npmignore
+++ b/packages/origin-247-claim/.npmignore
@@ -1,0 +1,5 @@
+*
+!dist/js/src/**/*
+!dist/js/ormconfig.js
+!dist/js/ormconfig-dev.js
+!dist/js/migrations/**/*

--- a/packages/origin-247-claim/README.md
+++ b/packages/origin-247-claim/README.md
@@ -1,0 +1,1 @@
+# Origin 24/7 SDK - Claim module

--- a/packages/origin-247-claim/ormconfig-dev.ts
+++ b/packages/origin-247-claim/ormconfig-dev.ts
@@ -1,0 +1,34 @@
+import { ConnectionOptions } from 'typeorm';
+
+const getDBConnectionOptions = (): ConnectionOptions => {
+    return process.env.DATABASE_URL
+        ? {
+              type: 'postgres',
+              url: process.env.DATABASE_URL,
+              ssl: {
+                  rejectUnauthorized: false
+              }
+          }
+        : {
+              type: 'postgres',
+              host: process.env.DB_HOST ?? 'localhost',
+              port: Number(process.env.DB_PORT) ?? 5432,
+              username: process.env.DB_USERNAME ?? 'postgres',
+              password: process.env.DB_PASSWORD ?? 'postgres',
+              database: process.env.DB_DATABASE ?? 'origin'
+          };
+};
+
+const config: ConnectionOptions = {
+    ...getDBConnectionOptions(),
+    entities: ['src/**/*.entity.ts'],
+    synchronize: false,
+    migrationsRun: true,
+    migrations: ['migrations/*.ts'],
+    migrationsTableName: 'migrations_247_transfer',
+    cli: {
+        migrationsDir: 'migrations'
+    }
+};
+
+export = config;

--- a/packages/origin-247-claim/ormconfig.ts
+++ b/packages/origin-247-claim/ormconfig.ts
@@ -1,0 +1,30 @@
+import { ConnectionOptions } from 'typeorm';
+
+const getDBConnectionOptions = (): ConnectionOptions => {
+    return process.env.DATABASE_URL
+        ? {
+              type: 'postgres',
+              url: process.env.DATABASE_URL,
+              ssl: {
+                  rejectUnauthorized: false
+              }
+          }
+        : {
+              type: 'postgres',
+              host: process.env.DB_HOST ?? 'localhost',
+              port: Number(process.env.DB_PORT) ?? 5432,
+              username: process.env.DB_USERNAME ?? 'postgres',
+              password: process.env.DB_PASSWORD ?? 'postgres',
+              database: process.env.DB_DATABASE ?? 'origin'
+          };
+};
+
+const config: ConnectionOptions = {
+    ...getDBConnectionOptions(),
+    synchronize: false,
+    migrationsRun: true,
+    migrations: [`${__dirname}/migrations/*.js`],
+    migrationsTableName: 'migrations_247_transfer'
+};
+
+export = config;

--- a/packages/origin-247-claim/package.json
+++ b/packages/origin-247-claim/package.json
@@ -1,0 +1,71 @@
+{
+    "name": "@energyweb/origin-247-claim",
+    "version": "0.0.1",
+    "main": "./dist/js/src/index.js",
+    "types": "./dist/js/src/index.d.ts",
+    "scripts": {
+        "test:unit": "jest --testRegex '\\.spec\\.ts$'",
+        "test:e2e": "concurrently --success first --kill-others -n eth,test \"yarn run:ganache\" \"wait-on tcp:8546 && yarn drop && yarn migrate && yarn test:e2e:jest\"",
+        "test:e2e:jest": "WEB3=http://localhost:8546 jest --testRegex '.e2e-spec.ts$' --forceExit",
+        "build": "tsc -b tsconfig.json",
+        "migrate": "yarn typeorm:run && yarn typeorm:run:issuer",
+        "drop": "yarn typeorm:drop && yarn typeorm:drop:issuer",
+        "typeorm": "ts-node -r tsconfig-paths/register node_modules/typeorm/cli.js --config ormconfig-dev.ts",
+        "typeorm:drop": "yarn typeorm schema:drop",
+        "typeorm:run": "yarn typeorm migration:run",
+        "typeorm:run:issuer": "node_modules/typeorm/cli.js migration:run --config node_modules/@energyweb/issuer-api/dist/js/ormconfig.js",
+        "typeorm:drop:issuer": "node_modules/typeorm/cli.js schema:drop --config node_modules/@energyweb/issuer-api/dist/js/ormconfig.js",
+        "run:ganache": "ganache-cli -q -m 'govern long helmet alert stay supply kick knife boss until buzz unlock' -l 8000000 -e 1000000 -a 20 -p 8546",
+        "publish:canary": "lerna publish --yes --skip-git --exact --cd-version=prerelease --pre-dist-tag canary --preid=alpha.$BUILD_ID",
+        "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes"
+    },
+    "dependencies": {
+        "@nestjs/common": "7.6.18",
+        "@nestjs/core": "7.6.18",
+        "@nestjs/cqrs": "7.0.1",
+        "@nestjs/typeorm": "7.1.5",
+        "ethers": "5.4.1",
+        "pg": "8.6.0",
+        "typeorm": "0.2.34",
+        "lodash": "4.17.21"
+    },
+    "peerDependencies": {
+        "@energyweb/origin-247-certificate": "^0.0.2-alpha.1626083770.0"
+    },
+    "devDependencies": {
+        "@nestjs/passport": "7.1.5",
+        "@nestjs/platform-express": "7.6.18",
+        "@nestjs/testing": "7.6.18",
+        "@types/jest": "26.0.23",
+        "@types/node": "15.12.4",
+        "jest": "27.0.5",
+        "ts-jest": "27.0.3",
+        "ts-node": "9.1.1",
+        "ganache-cli": "6.12.2",
+        "concurrently": "6.2.0",
+        "wait-on": "5.3.0",
+        "typescript": "4.3.4",
+        "@types/lodash": "4.14.171",
+        "@energyweb/issuer": "3.2.1-alpha.1625651017.0",
+        "@energyweb/issuer-api": "0.2.1-alpha.1625651017.0",
+        "@energyweb/origin-backend-utils": "1.5.2-alpha.1625651017.0",
+        "@energyweb/utils-general": "11.0.3-alpha.1625651017.0",
+        "@nestjs/bull": "0.3.1",
+        "bull": "3.22.9",
+        "tsconfig-paths": "3.10.1",
+        "class-transformer": "0.4.0"
+    },
+    "jest": {
+        "moduleFileExtensions": [
+            "js",
+            "json",
+            "ts"
+        ],
+        "rootDir": ".",
+        "transform": {
+            "^.+\\.(t|j)s$": "ts-jest"
+        },
+        "coverageDirectory": "../coverage",
+        "testEnvironment": "node"
+    }
+}

--- a/packages/origin-247-claim/package.json
+++ b/packages/origin-247-claim/package.json
@@ -5,8 +5,8 @@
     "types": "./dist/js/src/index.d.ts",
     "scripts": {
         "test:unit": "jest --testRegex '\\.spec\\.ts$'",
-        "test:e2e": "concurrently --success first --kill-others -n eth,test \"yarn run:ganache\" \"wait-on tcp:8546 && yarn drop && yarn migrate && yarn test:e2e:jest\"",
-        "test:e2e:jest": "WEB3=http://localhost:8546 jest --testRegex '.e2e-spec.ts$' --forceExit",
+        "test:e2e": "concurrently --success first --kill-others -n eth,test \"yarn run:ganache\" \"wait-on tcp:8547 && yarn drop && yarn migrate && yarn test:e2e:jest\"",
+        "test:e2e:jest": "WEB3=http://localhost:8547 jest --testRegex '.e2e-spec.ts$' --forceExit --passWithNoTests",
         "build": "tsc -b tsconfig.json",
         "migrate": "yarn typeorm:run && yarn typeorm:run:issuer",
         "drop": "yarn typeorm:drop && yarn typeorm:drop:issuer",
@@ -15,7 +15,7 @@
         "typeorm:run": "yarn typeorm migration:run",
         "typeorm:run:issuer": "node_modules/typeorm/cli.js migration:run --config node_modules/@energyweb/issuer-api/dist/js/ormconfig.js",
         "typeorm:drop:issuer": "node_modules/typeorm/cli.js schema:drop --config node_modules/@energyweb/issuer-api/dist/js/ormconfig.js",
-        "run:ganache": "ganache-cli -q -m 'govern long helmet alert stay supply kick knife boss until buzz unlock' -l 8000000 -e 1000000 -a 20 -p 8546",
+        "run:ganache": "ganache-cli -q -m 'govern long helmet alert stay supply kick knife boss until buzz unlock' -l 8000000 -e 1000000 -a 20 -p 8547",
         "publish:canary": "lerna publish --yes --skip-git --exact --cd-version=prerelease --pre-dist-tag canary --preid=alpha.$BUILD_ID",
         "publish:release": "lerna version --create-release github --conventional-commits --exact --yes --message \"chore(release): publish /skip-deploy\" && lerna publish from-git --yes"
     },

--- a/packages/origin-247-claim/src/algorithms/index.ts
+++ b/packages/origin-247-claim/src/algorithms/index.ts
@@ -1,0 +1,1 @@
+export * from './matcher';

--- a/packages/origin-247-claim/src/algorithms/index.ts
+++ b/packages/origin-247-claim/src/algorithms/index.ts
@@ -1,1 +1,1 @@
-export * from './matcher';
+export * from './spreadMatcher';

--- a/packages/origin-247-claim/src/algorithms/matcher.ts
+++ b/packages/origin-247-claim/src/algorithms/matcher.ts
@@ -1,0 +1,197 @@
+import { groupBy, minBy, sumBy, cloneDeep } from 'lodash';
+
+type ConsumerId = string;
+type GeneratorId = string;
+
+export interface MatcherData {
+    priority: {
+        id: string;
+        priority: { id: string }[][];
+    }[][];
+    entityGroups: [Entity[], Entity[]];
+}
+
+export interface Match {
+    entities: [string, string];
+    volume: number;
+}
+
+export interface MatcherResult {
+    matches: Match[];
+    leftoverEntities: [Entity[], Entity[]];
+}
+
+interface Entity {
+    id: string;
+    volume: number;
+}
+
+type Route = [ConsumerId, GeneratorId];
+
+interface RoundInput {
+    routes: Route[];
+    entityGroups: [Entity[], Entity[]];
+}
+
+export const matcher = (originalData: MatcherData): MatcherResult => {
+    const data = cloneDeep(originalData);
+    const matches: Match[][] = [];
+
+    let i = 0;
+
+    while (true) {
+        if (i > 10000) {
+            throw new Error(`
+              Matching executed more than 10000 - it may mean, that something broke
+              data: ${JSON.stringify(data, null, 2)}
+              matches: not displayed, because of potential length
+            `);
+        }
+
+        const allGroupsHaveVolume = [
+            data.entityGroups[0].some((v) => v.volume > 0),
+            data.entityGroups[1].some((v) => v.volume > 0)
+        ].every(Boolean);
+
+        if (!allGroupsHaveVolume) {
+            break;
+        }
+
+        const roundMatches = matchRound(getRoundInput(data));
+
+        roundMatches.forEach((match) => {
+            data.entityGroups[0].find((c) => c.id === match.entities[0])!.volume -= match.volume;
+            data.entityGroups[1].find((g) => g.id === match.entities[1])!.volume -= match.volume;
+        });
+
+        matches.push(roundMatches);
+
+        i += 1;
+    }
+
+    return {
+        matches: sumMatches(matches.flat()),
+        leftoverEntities: data.entityGroups
+    };
+};
+
+/**
+ * Given matches sums them together - multiple matches for the same entities can happen,
+ * and we want sum of these matches.
+ */
+const sumMatches = (matches: Match[]): Match[] => {
+    return Object.values(groupBy(matches, (m) => `${m.entities[0]}${m.entities[1]}`)).map(
+        (matches) => ({
+            entities: matches[0].entities,
+            volume: sumBy(matches, (m) => m.volume)
+        })
+    );
+};
+
+/**
+ * Given two set of entities it checks how much volume should be distributed in each match round.
+ * It's not optimal, but it's safe - it divides entity volumes over second entities count,
+ * and that's easiest method to compute volume, that can be distributed without any errors in algorithm.
+ */
+const computeSafeDistribution = (entities1: Entity[], entities2: Entity[]) => {
+    const compute = (entities: Entity[], otherEntitiesLength: number) =>
+        entities.map((entity) => ({
+            entityId: entity.id,
+            volume: entity.volume,
+            distributedVolume: Math.floor(entity.volume / otherEntitiesLength)
+        }));
+
+    return minBy(
+        [...compute(entities1, entities2.length), ...compute(entities2, entities1.length)],
+        (e) => e.distributedVolume
+    )!;
+};
+
+/**
+ * Return entities, that are connected to given entity by a route.
+ * This way we can find all entities that will be competing over another entity.
+ */
+const getCompetingEntites = (routes: Route[], entityId: string) => {
+    return routes
+        .filter((route) => route.includes(entityId))
+        .flat()
+        .filter((id) => id !== entityId);
+};
+
+/**
+ * Create matches
+ */
+const matchRound = (input: RoundInput): Match[] => {
+    const entityToDistribute = computeSafeDistribution(
+        input.entityGroups[0],
+        input.entityGroups[1]
+    );
+
+    if (entityToDistribute.distributedVolume === 0) {
+        const competetingEntities = getCompetingEntites(input.routes, entityToDistribute.entityId);
+
+        // Since each entity will receive one volume, these numbers are equal
+        const entitiesCountToUse = entityToDistribute.volume;
+
+        // We need to check to which group entity to distribute belongs
+        const isEntityFirst = input.entityGroups[0].find(
+            (e) => e.id === entityToDistribute.entityId
+        );
+
+        return competetingEntities.slice(0, entitiesCountToUse).map((connectedEntity) => ({
+            entities: isEntityFirst
+                ? [entityToDistribute.entityId, connectedEntity]
+                : [connectedEntity, entityToDistribute.entityId],
+            volume: 1
+        }));
+    }
+
+    return input.routes.map((route) => ({
+        entities: route,
+        volume: entityToDistribute.distributedVolume
+    }));
+};
+
+/**
+ * Return organized input for next matching rout
+ */
+const getRoundInput = (data: MatcherData): RoundInput => {
+    const entity1round = getFirstUsableGroup(data.priority, data.entityGroups[0]);
+
+    const routes = entity1round.flatMap((entity1) => {
+        const prefferedGeneratorGroup = getFirstUsableGroup(entity1.priority, data.entityGroups[1]);
+
+        return prefferedGeneratorGroup.map(
+            (entity2) => [entity1.id, entity2.id] as [string, string]
+        );
+    });
+
+    return {
+        routes,
+        entityGroups: [
+            data.entityGroups[0].filter((entity) => routes.some((e) => e[0] === entity.id)),
+            data.entityGroups[1].filter((entity) => routes.some((e) => e[1] === entity.id))
+        ]
+    };
+};
+
+/**
+ * Given groups, and related entities with volumes
+ * it returns first group that has any volume left.
+ * It also removes entries from group, that don't have any volume.
+ */
+const getFirstUsableGroup = <T extends { id: string }>(groups: T[][], data: Entity[]) => {
+    const groupsWithVolume = groups
+        .map((group) => {
+            const withVolume = group.map((entry) => ({
+                ...entry,
+                // it is possible that some entry in group has no consumption/generation
+                volume: data.find((c) => c.id === entry.id)?.volume ?? 0
+            }));
+
+            return withVolume.filter((entry) => entry.volume > 0);
+        })
+        .filter((group) => group.length > 0);
+
+    return groupsWithVolume[0] ?? [];
+};

--- a/packages/origin-247-claim/src/index.ts
+++ b/packages/origin-247-claim/src/index.ts
@@ -1,0 +1,1 @@
+export * from './algorithms';

--- a/packages/origin-247-claim/tests/matcher.spec.ts
+++ b/packages/origin-247-claim/tests/matcher.spec.ts
@@ -1,9 +1,10 @@
-import { spreadMatcher } from '../src';
+import { BigNumber } from 'ethers';
+import { spreadMatcher, SpreadMatcherData, SpreadMatcherEntity, SpreadMatcherResult } from '../src';
 
 describe('spreadMatcher', () => {
     describe('consumer priority', () => {
         it('2 consumers within same group - should distribute evenly between same priority consumers', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -68,7 +69,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 consumers within same group - should distribute evenly between same priority consumers, regardless of consumptions', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -133,7 +134,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 consumers within same group - should distribute one more to first consumer when generations are indivisible equally', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -198,7 +199,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 consumers within same group - should distribute evenly between same priority consumers', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -280,7 +281,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (1) to first consumer', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -362,7 +363,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (2) from different generators to first consumer', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -449,7 +450,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 consumers within different groups - should satisfy higher priority group first', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }],
                     [{ id: 'consumerB', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
@@ -507,7 +508,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 consumer priority groups, 2 consumer each - should satisfy higher priority group first', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -613,7 +614,7 @@ describe('spreadMatcher', () => {
 
     describe('generator priority', () => {
         it('2 generators - should distribute evenly between same priority generators', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
                 ],
@@ -654,7 +655,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
                 ],
@@ -678,7 +679,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 generators - should distribute evenly between same priority generators', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -735,7 +736,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -791,7 +792,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 generators - should distribute last indivisible consumption (2) from first two generations on list', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -847,7 +848,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 generators and 2 consumers - should distribute evenly between same priority generators', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -891,7 +892,7 @@ describe('spreadMatcher', () => {
         });
 
         it('3 generators and 2 consumers - should distribute evenly between same priority generators', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -948,7 +949,7 @@ describe('spreadMatcher', () => {
         });
 
         it('2 generators and 3 consumers - should distribute evenly between same priority generators', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -1018,7 +1019,7 @@ describe('spreadMatcher', () => {
 
     describe('leftover consumptions', () => {
         it('should return only leftover consumptions when there are no generations', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -1061,7 +1062,7 @@ describe('spreadMatcher', () => {
         });
 
         it('should return leftover consumptions when the generations cannot satisfy all consumptions', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
@@ -1101,7 +1102,7 @@ describe('spreadMatcher', () => {
 
     describe('excess generations', () => {
         it('should return only excess generations when there are no consumptions to satisfy', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         {
@@ -1127,7 +1128,7 @@ describe('spreadMatcher', () => {
         });
 
         it('should return excess generations when the consumptions are satisfied and there are generations left', () => {
-            const result = spreadMatcher({
+            const result = integerMatcher({
                 priority: [
                     [
                         { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
@@ -1153,3 +1154,39 @@ describe('spreadMatcher', () => {
     });
     // Matching algorithm end
 });
+
+type Primitive = string | number | boolean | undefined | null;
+type IntegerVolume<T> = {
+    [K in keyof T]: T[K] extends BigNumber
+        ? number
+        : T[K] extends Primitive
+        ? T[K]
+        : IntegerVolume<T[K]>;
+};
+
+const integerMatcher = (
+    params: IntegerVolume<SpreadMatcherData>
+): IntegerVolume<SpreadMatcherResult> => {
+    const result = spreadMatcher({
+        priority: params.priority,
+        entityGroups: params.entityGroups.map((g) =>
+            g.map((e) => ({
+                id: e.id,
+                volume: BigNumber.from(e.volume)
+            }))
+        ) as [SpreadMatcherEntity[], SpreadMatcherEntity[]]
+    });
+
+    return {
+        leftoverEntities: result.leftoverEntities.map((g) =>
+            g.map((e) => ({
+                id: e.id,
+                volume: e.volume.toNumber()
+            }))
+        ) as any,
+        matches: result.matches.map((m) => ({
+            ...m,
+            volume: m.volume.toNumber()
+        }))
+    };
+};

--- a/packages/origin-247-claim/tests/matcher.spec.ts
+++ b/packages/origin-247-claim/tests/matcher.spec.ts
@@ -1,9 +1,9 @@
-import { matcher } from '../src';
+import { spreadMatcher } from '../src';
 
-describe('Matcher', () => {
+describe('spreadMatcher', () => {
     describe('consumer priority', () => {
         it('2 consumers within same group - should distribute evenly between same priority consumers', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -68,7 +68,7 @@ describe('Matcher', () => {
         });
 
         it('2 consumers within same group - should distribute evenly between same priority consumers, regardless of consumptions', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -133,7 +133,7 @@ describe('Matcher', () => {
         });
 
         it('2 consumers within same group - should distribute one more to first consumer when generations are indivisible equally', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -198,7 +198,7 @@ describe('Matcher', () => {
         });
 
         it('3 consumers within same group - should distribute evenly between same priority consumers', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -280,7 +280,7 @@ describe('Matcher', () => {
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (1) to first consumer', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -362,7 +362,7 @@ describe('Matcher', () => {
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (2) from different generators to first consumer', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -449,7 +449,7 @@ describe('Matcher', () => {
         });
 
         it('2 consumers within different groups - should satisfy higher priority group first', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }],
                     [{ id: 'consumerB', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
@@ -507,7 +507,7 @@ describe('Matcher', () => {
         });
 
         it('2 consumer priority groups, 2 consumer each - should satisfy higher priority group first', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -613,7 +613,7 @@ describe('Matcher', () => {
 
     describe('generator priority', () => {
         it('2 generators - should distribute evenly between same priority generators', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
                 ],
@@ -654,7 +654,7 @@ describe('Matcher', () => {
         });
 
         it('2 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
                 ],
@@ -678,7 +678,7 @@ describe('Matcher', () => {
         });
 
         it('3 generators - should distribute evenly between same priority generators', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -735,7 +735,7 @@ describe('Matcher', () => {
         });
 
         it('3 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -791,7 +791,7 @@ describe('Matcher', () => {
         });
 
         it('3 generators - should distribute last indivisible consumption (2) from first two generations on list', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -847,7 +847,7 @@ describe('Matcher', () => {
         });
 
         it('2 generators and 2 consumers - should distribute evenly between same priority generators', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -891,7 +891,7 @@ describe('Matcher', () => {
         });
 
         it('3 generators and 2 consumers - should distribute evenly between same priority generators', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -948,7 +948,7 @@ describe('Matcher', () => {
         });
 
         it('2 generators and 3 consumers - should distribute evenly between same priority generators', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -1018,7 +1018,7 @@ describe('Matcher', () => {
 
     describe('leftover consumptions', () => {
         it('should return only leftover consumptions when there are no generations', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -1061,7 +1061,7 @@ describe('Matcher', () => {
         });
 
         it('should return leftover consumptions when the generations cannot satisfy all consumptions', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
@@ -1101,7 +1101,7 @@ describe('Matcher', () => {
 
     describe('excess generations', () => {
         it('should return only excess generations when there are no consumptions to satisfy', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         {
@@ -1127,7 +1127,7 @@ describe('Matcher', () => {
         });
 
         it('should return excess generations when the consumptions are satisfied and there are generations left', () => {
-            const result = matcher({
+            const result = spreadMatcher({
                 priority: [
                     [
                         { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },

--- a/packages/origin-247-claim/tests/matcher.spec.ts
+++ b/packages/origin-247-claim/tests/matcher.spec.ts
@@ -1,0 +1,1155 @@
+import { matcher } from '../src';
+
+describe('Matcher', () => {
+    describe('consumer priority', () => {
+        it('2 consumers within same group - should distribute evenly between same priority consumers', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 150 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(4);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 75
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 75
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('2 consumers within same group - should distribute evenly between same priority consumers, regardless of consumptions', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 150 },
+                        { id: 'consumerB', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 150 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(4);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 75
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 75
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 50
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('2 consumers within same group - should distribute one more to first consumer when generations are indivisible equally', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 149 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(4);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 75
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 74
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 1
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('3 consumers within same group - should distribute evenly between same priority consumers', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 },
+                        { id: 'consumerC', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 75 },
+                        { id: 'generatorB', volume: 150 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(6);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 50
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 50
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerC', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerC', 'generatorB'],
+                volume: 50
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 25
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 25
+            });
+            expect(result.leftoverEntities[0][2]).toEqual({
+                id: 'consumerC',
+                volume: 25
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('3 consumers within same group - should distribute last indivisible generation (1) to first consumer', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 },
+                        { id: 'consumerC', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 100 },
+                        { id: 'generatorB', volume: 99 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(6);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 34
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 33
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 33
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 33
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerC', 'generatorA'],
+                volume: 33
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerC', 'generatorB'],
+                volume: 33
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 33
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 34
+            });
+            expect(result.leftoverEntities[0][2]).toEqual({
+                id: 'consumerC',
+                volume: 34
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('3 consumers within same group - should distribute last indivisible generation (2) from different generators to first consumer', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 },
+                        { id: 'consumerC', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 100 },
+                        { id: 'generatorB', volume: 100 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(6);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 34
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 34
+            });
+            // It's getting unequally distributed and provided to consumerA,
+            // because the distribution happens on two generations (1 generation on each generator)
+            // which means that it happens in two separate and independent rounds
+            // and in case of 1 generation left - it's distributed to first consumer on list
+
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 33
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 33
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerC', 'generatorA'],
+                volume: 33
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerC', 'generatorB'],
+                volume: 33
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 32
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 34
+            });
+            expect(result.leftoverEntities[0][2]).toEqual({
+                id: 'consumerC',
+                volume: 34
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('2 consumers within different groups - should satisfy higher priority group first', () => {
+            const result = matcher({
+                priority: [
+                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }],
+                    [{ id: 'consumerB', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 150 },
+                        { id: 'consumerB', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 100 },
+                        { id: 'generatorB', volume: 100 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(4);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 75
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 75
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 25
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 50
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+
+        it('2 consumer priority groups, 2 consumer each - should satisfy higher priority group first', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ],
+                    [
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerD',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 100 },
+                        { id: 'consumerB', volume: 100 },
+                        { id: 'consumerC', volume: 100 },
+                        { id: 'consumerD', volume: 100 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 150 },
+                        { id: 'generatorB', volume: 150 }
+                    ]
+                ]
+            });
+
+            // expect(result.matches).toHaveLength(4);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 50
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 50
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 50
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 50
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerC', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerC', 'generatorB'],
+                volume: 25
+            });
+            expect(result.matches[6]).toEqual({
+                entities: ['consumerD', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[7]).toEqual({
+                entities: ['consumerD', 'generatorB'],
+                volume: 25
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 0
+            });
+            expect(result.leftoverEntities[0][2]).toEqual({
+                id: 'consumerC',
+                volume: 50
+            });
+
+            expect(result.leftoverEntities[0][3]).toEqual({
+                id: 'consumerD',
+                volume: 50
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 0
+            });
+        });
+        // consumer priority end
+    });
+
+    describe('generator priority', () => {
+        it('2 generators - should distribute evenly between same priority generators', () => {
+            const result = matcher({
+                priority: [
+                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: 100 }],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 150 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(2);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 50
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 50
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 0
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 100
+            });
+        });
+
+        it('2 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
+            const result = matcher({
+                priority: [
+                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: 51 }],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 50 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 26
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 25
+            });
+        });
+
+        it('3 generators - should distribute evenly between same priority generators', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [
+                                [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
+                            ]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: 120 }],
+                    [
+                        { id: 'generatorA', volume: 60 },
+                        { id: 'generatorB', volume: 60 },
+                        { id: 'generatorC', volume: 60 }
+                    ]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(3);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 40
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 40
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerA', 'generatorC'],
+                volume: 40
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 20
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 20
+            });
+            expect(result.leftoverEntities[1][2]).toEqual({
+                id: 'generatorC',
+                volume: 20
+            });
+        });
+
+        it('3 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [
+                                [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
+                            ]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: 100 }],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 50 },
+                        { id: 'generatorC', volume: 50 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 34
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 33
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerA', 'generatorC'],
+                volume: 33
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 16
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 17
+            });
+            expect(result.leftoverEntities[1][2]).toEqual({
+                id: 'generatorC',
+                volume: 17
+            });
+        });
+
+        it('3 generators - should distribute last indivisible consumption (2) from first two generations on list', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [
+                                [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
+                            ]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: 101 }],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 50 },
+                        { id: 'generatorC', volume: 50 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 34
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 34
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerA', 'generatorC'],
+                volume: 33
+            });
+
+            // leftover consumptions
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 0
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 16
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 16
+            });
+            expect(result.leftoverEntities[1][2]).toEqual({
+                id: 'generatorC',
+                volume: 17
+            });
+        });
+
+        it('2 generators and 2 consumers - should distribute evenly between same priority generators', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 50 },
+                        { id: 'consumerB', volume: 50 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 50 },
+                        { id: 'generatorB', volume: 50 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 25
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 25
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 25
+            });
+        });
+
+        it('3 generators and 2 consumers - should distribute evenly between same priority generators', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [
+                                [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
+                            ]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [
+                                [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
+                            ]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 30 },
+                        { id: 'consumerB', volume: 30 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 20 },
+                        { id: 'generatorB', volume: 20 },
+                        { id: 'generatorC', volume: 20 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 10
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 10
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerA', 'generatorC'],
+                volume: 10
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 10
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 10
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerB', 'generatorC'],
+                volume: 10
+            });
+        });
+
+        it('2 generators and 3 consumers - should distribute evenly between same priority generators', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 10 },
+                        { id: 'consumerB', volume: 10 },
+                        { id: 'consumerC', volume: 10 }
+                    ],
+                    [
+                        { id: 'generatorA', volume: 20 },
+                        { id: 'generatorB', volume: 20 }
+                    ]
+                ]
+            });
+
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 5
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerA', 'generatorB'],
+                volume: 5
+            });
+            expect(result.matches[2]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 5
+            });
+            expect(result.matches[3]).toEqual({
+                entities: ['consumerB', 'generatorB'],
+                volume: 5
+            });
+            expect(result.matches[4]).toEqual({
+                entities: ['consumerC', 'generatorA'],
+                volume: 5
+            });
+            expect(result.matches[5]).toEqual({
+                entities: ['consumerC', 'generatorB'],
+                volume: 5
+            });
+
+            // excess generations
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 5
+            });
+            expect(result.leftoverEntities[1][1]).toEqual({
+                id: 'generatorB',
+                volume: 5
+            });
+        });
+        // generator priority end
+    });
+
+    describe('leftover consumptions', () => {
+        it('should return only leftover consumptions when there are no generations', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerC',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 10 },
+                        { id: 'consumerB', volume: 10 },
+                        { id: 'consumerC', volume: 10 }
+                    ],
+                    []
+                ]
+            });
+
+            expect(result.matches).toHaveLength(0);
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 10
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 10
+            });
+            expect(result.leftoverEntities[0][2]).toEqual({
+                id: 'consumerC',
+                volume: 10
+            });
+        });
+
+        it('should return leftover consumptions when the generations cannot satisfy all consumptions', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
+                        { id: 'consumerB', priority: [[{ id: 'generatorA' }]] }
+                    ]
+                ],
+                entityGroups: [
+                    [
+                        { id: 'consumerA', volume: 10 },
+                        { id: 'consumerB', volume: 10 }
+                    ],
+                    [{ id: 'generatorA', volume: 10 }]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(2);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 5
+            });
+            expect(result.matches[1]).toEqual({
+                entities: ['consumerB', 'generatorA'],
+                volume: 5
+            });
+
+            expect(result.leftoverEntities[0][0]).toEqual({
+                id: 'consumerA',
+                volume: 5
+            });
+            expect(result.leftoverEntities[0][1]).toEqual({
+                id: 'consumerB',
+                volume: 5
+            });
+        });
+        // leftover consumptions end
+    });
+
+    describe('excess generations', () => {
+        it('should return only excess generations when there are no consumptions to satisfy', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        },
+                        {
+                            id: 'consumerB',
+                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
+                ],
+                entityGroups: [[], [{ id: 'generatorA', volume: 10 }]]
+            });
+
+            expect(result.matches).toHaveLength(0);
+            expect(result.leftoverEntities[0]).toHaveLength(0);
+            expect(result.leftoverEntities[1]).toHaveLength(1);
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 10
+            });
+        });
+
+        it('should return excess generations when the consumptions are satisfied and there are generations left', () => {
+            const result = matcher({
+                priority: [
+                    [
+                        { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
+                        { id: 'consumerB', priority: [[{ id: 'generatorA' }]] }
+                    ]
+                ],
+                entityGroups: [[{ id: 'consumerA', volume: 5 }], [{ id: 'generatorA', volume: 10 }]]
+            });
+
+            expect(result.matches).toHaveLength(1);
+            expect(result.matches[0]).toEqual({
+                entities: ['consumerA', 'generatorA'],
+                volume: 5
+            });
+
+            expect(result.leftoverEntities[1]).toHaveLength(1);
+            expect(result.leftoverEntities[1][0]).toEqual({
+                id: 'generatorA',
+                volume: 5
+            });
+        });
+        // excess generations end
+    });
+    // Matching algorithm end
+});

--- a/packages/origin-247-claim/tsconfig.json
+++ b/packages/origin-247-claim/tsconfig.json
@@ -19,6 +19,6 @@
         "resolveJsonModule": true,
         "preserveWatchOutput": true
     },
-    "include": ["src/**/*", "test/**/*", "migrations/*", "ormconfig*.ts"],
+    "include": ["src/**/*", "tests/**/*", "migrations/*", "ormconfig*.ts"],
     "exclude": ["node_modules", "dist"]
 }

--- a/packages/origin-247-claim/tsconfig.json
+++ b/packages/origin-247-claim/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": true,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "target": "ES2020",
+        "sourceMap": true,
+        "outDir": "./dist/js",
+        "baseUrl": "./",
+        "incremental": true,
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "types": ["jest", "node"],
+        "strictNullChecks": true,
+        "allowJs": true,
+        "resolveJsonModule": true,
+        "preserveWatchOutput": true
+    },
+    "include": ["src/**/*", "test/**/*", "migrations/*", "ormconfig*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/rush.json
+++ b/rush.json
@@ -387,6 +387,10 @@
         {
             "packageName": "@energyweb/origin-247-transfer",
             "projectFolder": "packages/origin-247-transfer"
+        },
+        {
+            "packageName": "@energyweb/origin-247-claim",
+            "projectFolder": "packages/origin-247-claim"
         }
         // {
         //   /**


### PR DESCRIPTION
This is config copied over from transfer module + spreadMatcher algo

Currently it doesn't support YET custom objects with custom metadata, so it requires kindof hacking on application to differentiate for example generators from different certificates. Gonna work on that