### PR TITLE
feat(origin-247-claim)!: work with generic entities instead of entity ID

### DIFF
--- a/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
+++ b/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
@@ -1,210 +1,279 @@
-import { groupBy, cloneDeep } from 'lodash';
+import { omit, cloneDeep } from 'lodash';
 import { BigNumber } from 'ethers';
 
-export interface SpreadMatcherData {
-    priority: {
+export namespace SpreadMatcher {
+    /**
+     * Entity, that will be distributed over another entities
+     */
+    export interface Entity {
         id: string;
-        priority: { id: string }[][];
-    }[][];
-    entityGroups: [SpreadMatcherEntity[], SpreadMatcherEntity[]];
-}
-
-export interface SpreadMatch {
-    entities: [string, string];
-    volume: BigNumber;
-}
-
-export interface SpreadMatcherResult {
-    matches: SpreadMatch[];
-    leftoverEntities: [SpreadMatcherEntity[], SpreadMatcherEntity[]];
-}
-
-export interface SpreadMatcherEntity {
-    id: string;
-    volume: BigNumber;
-}
-
-type Route = [string, string];
-
-interface RoundInput {
-    routes: Route[];
-    entityGroups: [SpreadMatcherEntity[], SpreadMatcherEntity[]];
-}
-
-export const spreadMatcher = (originalData: SpreadMatcherData): SpreadMatcherResult => {
-    const data = cloneDeep(originalData);
-    const matches: SpreadMatch[][] = [];
-
-    let i = 0;
-
-    while (true) {
-        if (i > 10000) {
-            throw new Error(`
-              Matching executed more than 10000 - it may mean, that something broke
-              data: ${JSON.stringify(data, null, 2)}
-              matches: not displayed, because of potential length
-            `);
-        }
-
-        const allGroupsHaveVolume = [
-            data.entityGroups[0].some((v) => v.volume.gt(0)),
-            data.entityGroups[1].some((v) => v.volume.gt(0))
-        ].every(Boolean);
-
-        if (!allGroupsHaveVolume) {
-            break;
-        }
-
-        const roundMatches = matchRound(getRoundInput(data));
-
-        roundMatches.forEach((match) => {
-            const entity1 = data.entityGroups[0].find((c) => c.id === match.entities[0])!;
-            const entity2 = data.entityGroups[1].find((g) => g.id === match.entities[1])!;
-
-            entity1.volume = entity1.volume.sub(match.volume);
-            entity2.volume = entity2.volume.sub(match.volume);
-        });
-
-        matches.push(roundMatches);
-
-        i += 1;
+        volume: BigNumber;
     }
 
-    return {
-        matches: sumMatches(matches.flat()),
-        leftoverEntities: data.entityGroups
-    };
-};
-
-/**
- * Given matches sums them together - multiple matches for the same entities can happen,
- * and we want sum of these matches.
- */
-const sumMatches = (matches: SpreadMatch[]): SpreadMatch[] => {
-    return Object.values(groupBy(matches, (m) => `${m.entities[0]}${m.entities[1]}`)).map(
-        (matches) => ({
-            entities: matches[0].entities,
-            volume: bigNumSum(matches.map((m) => m.volume))
-        })
-    );
-};
-
-/**
- * Given two set of entities it checks how much volume should be distributed in each match round.
- * It's not optimal, but it's safe - it divides entity volumes over second entities count,
- * and that's easiest method to compute volume, that can be distributed without any errors in algorithm.
- */
-const computeSafeDistribution = (
-    entities1: SpreadMatcherEntity[],
-    entities2: SpreadMatcherEntity[]
-) => {
-    const compute = (entities: SpreadMatcherEntity[], otherEntitiesLength: number) =>
-        entities.map((entity) => ({
-            entityId: entity.id,
-            volume: entity.volume,
-            distributedVolume: entity.volume.div(otherEntitiesLength)
-        }));
-
-    return bigNumMinBy(
-        [...compute(entities1, entities2.length), ...compute(entities2, entities1.length)],
-        (e) => e.distributedVolume
-    );
-};
-
-/**
- * Return entities, that are connected to given entity by a route.
- * This way we can find all entities that will be competing over another entity.
- */
-const getCompetingEntities = (routes: Route[], entityId: string) => {
-    return routes
-        .filter((route) => route.includes(entityId))
-        .flat()
-        .filter((id) => id !== entityId);
-};
-
-/**
- * Create matches
- */
-const matchRound = (input: RoundInput): SpreadMatch[] => {
-    const entityToDistribute = computeSafeDistribution(
-        input.entityGroups[0],
-        input.entityGroups[1]
-    );
-
-    if (entityToDistribute.distributedVolume.eq(0)) {
-        const competingEntities = getCompetingEntities(input.routes, entityToDistribute.entityId);
-
-        // Since each entity will receive one volume, these numbers are equal
-        const entitiesCountToUse = entityToDistribute.volume.toNumber(); // low enough
-
-        // We need to check to which group entity to distribute belongs
-        const isEntityFirst = input.entityGroups[0].find(
-            (e) => e.id === entityToDistribute.entityId
-        );
-
-        return competingEntities.slice(0, entitiesCountToUse).map((connectedEntity) => ({
-            entities: isEntityFirst
-                ? [entityToDistribute.entityId, connectedEntity]
-                : [connectedEntity, entityToDistribute.entityId],
-            volume: BigNumber.from(1)
-        }));
+    export interface Params<T extends Entity, P extends Entity> {
+        /** First entity group priority */
+        groupPriority: {
+            id: string;
+            /** Second entity group priority */
+            groupPriority: { id: string }[][];
+        }[][];
+        entityGroups: [T[], P[]];
     }
 
-    return input.routes.map((route) => ({
-        entities: route,
-        volume: entityToDistribute.distributedVolume
-    }));
-};
+    export interface Match<T extends Entity, P extends Entity> {
+        /** Volumes are omitted to avoid confusion, though they are expected to be 0 */
+        entities: [Omit<T, 'volume'>, Omit<P, 'volume'>];
+        volume: BigNumber;
+    }
 
-/**
- * Return organized input for next matching rout
- */
-const getRoundInput = (data: SpreadMatcherData): RoundInput => {
-    const entity1round = getFirstUsableGroup(data.priority, data.entityGroups[0]);
+    export interface Result<T extends Entity, P extends Entity> {
+        matches: Match<T, P>[];
+        leftoverEntities: [T[], P[]];
+    }
 
-    const routes = entity1round.flatMap((entity1) => {
-        const preferredEntity2Group = getFirstUsableGroup(entity1.priority, data.entityGroups[1]);
+    /** Possible connection between two entities (one will satisfy another) */
+    type Route<T extends Entity, P extends Entity> = [T, P];
 
-        return preferredEntity2Group.map((entity2) => [entity1.id, entity2.id] as [string, string]);
-    });
+    interface RoundInput<T extends Entity, P extends Entity> {
+        routes: Route<T, P>[];
+        entityGroups: [T[], P[]];
+    }
 
-    return {
-        routes,
-        entityGroups: [
-            data.entityGroups[0].filter((entity) => routes.some((e) => e[0] === entity.id)),
-            data.entityGroups[1].filter((entity) => routes.some((e) => e[1] === entity.id))
-        ]
+    /**
+     * @NOTE
+     *
+     * ==============================
+     * This code relies heavily on identity equality.
+     * Entities are cloned at the beginning, and since then,
+     * reference cannot be lost
+     *
+     * Because entities may contain many fields, that are not supported by algorithm,
+     * we would not know how to differentiate them: `id` can be not sufficient in many cases.
+     * At the same, priority groups will work with `id` only.
+     *
+     * This is why entities are differentiated using strict equality.
+     * Multiple entities with the same `id` will be treated as belonging to the same priority group,
+     * therefore they will be consumed/satisfied equally.
+     * ==============================
+     */
+
+    /**
+     * Perform match of entityGroups according to groupPriority.
+     * For equal priorities of entities, they are used up equally - thus spread.
+     */
+    export const spreadMatcher = <T extends Entity, P extends Entity>(
+        originalData: Params<T, P>
+    ): Result<T, P> => {
+        const data = cloneDeep(originalData);
+        const matches = [] as Match<T, P>[][];
+
+        let i = 0;
+        while ((i += 1)) {
+            if (i > 10000) {
+                throw new Error(`
+                  Matching executed more than 10000 - it may mean, that something broke
+                  data: ${JSON.stringify(data)}
+                  matches: not displayed, because of potential length
+                `);
+            }
+
+            const allGroupsHaveVolume = [
+                data.entityGroups[0].some((v) => v.volume.gt(0)),
+                data.entityGroups[1].some((v) => v.volume.gt(0))
+            ].every(Boolean);
+
+            if (!allGroupsHaveVolume) {
+                break;
+            }
+
+            const roundMatches = matchRound(getRoundInput(data));
+
+            roundMatches.forEach((match) => {
+                const entity1 = data.entityGroups[0].find((e) => e === match.entities[0])!;
+                const entity2 = data.entityGroups[1].find((e) => e === match.entities[1])!;
+
+                entity1.volume = entity1.volume.sub(match.volume);
+                entity2.volume = entity2.volume.sub(match.volume);
+            });
+
+            matches.push(roundMatches);
+        }
+
+        return {
+            matches: sumMatches(matches.flat()).map(omitMatchVolumes) as Match<T, P>[],
+            leftoverEntities: data.entityGroups
+        };
     };
-};
 
-/**
- * Given groups, and related entities with volumes
- * it returns first group that has any volume left.
- * It also removes entries from group, that don't have any volume.
- */
-const getFirstUsableGroup = <T extends { id: string }>(
-    groups: T[][],
-    data: SpreadMatcherEntity[]
-) => {
-    const groupsWithVolume = groups
-        .map((group) => {
-            const withVolume = group.map((entry) => ({
-                ...entry,
-                // it is possible that some entry in group has no data volume
-                volume: data.find((c) => c.id === entry.id)?.volume ?? BigNumber.from(0)
+    const omitMatchVolumes = <T extends Entity, P extends Entity>(match: Match<T, P>) => {
+        return {
+            ...match,
+            entities: match.entities.map((e) => omit(e, 'volume'))
+        };
+    };
+
+    /**
+     * Multiple matches for the same entities can happen,
+     * and we want sum of these.
+     */
+    const sumMatches = <T extends Entity, P extends Entity>(
+        matches: Match<T, P>[]
+    ): Match<T, P>[] => {
+        const areMatchesSame = (match1: Match<T, P>, match2: Match<T, P>) => {
+            return (
+                match1.entities[0] === match2.entities[0] &&
+                match1.entities[1] === match2.entities[1]
+            );
+        };
+
+        return matches.reduce((sum, match) => {
+            const existingMatch = sum.find((s) => areMatchesSame(s, match));
+
+            if (existingMatch) {
+                existingMatch.volume = existingMatch.volume.add(match.volume);
+                return sum;
+            }
+
+            return [...sum, match];
+        }, [] as Match<T, P>[]);
+    };
+
+    /**
+     * Given two set of entities it checks how much volume should be distributed in each match round.
+     * It's not optimal, but it's safe - it divides entity volumes over second entities count,
+     * and that's easiest method to compute volume, that can be distributed without any errors in algorithm.
+     */
+    const computeSafeDistribution = <T extends Entity, P extends Entity>(
+        entities1: T[],
+        entities2: P[]
+    ) => {
+        const computeDistributedVolume = (entities: (T | P)[], otherEntitiesLength: number) =>
+            entities.map((entity) => ({
+                entity,
+                volume: entity.volume.div(otherEntitiesLength) // automatically rounded down
             }));
 
-            return withVolume.filter((entry) => entry.volume.gt(0));
-        })
-        .filter((group) => group.length > 0);
+        return bigNumMinBy(
+            [
+                ...computeDistributedVolume(entities1, entities2.length),
+                ...computeDistributedVolume(entities2, entities1.length)
+            ],
+            (e) => e.volume
+        );
+    };
 
-    return groupsWithVolume[0] ?? [];
-};
+    /**
+     * Return entities, that are connected to given entity by a route.
+     * This way we can find all entities that will be competing over another entity.
+     */
+    const getCompetingEntities = <T extends Entity, P extends Entity>(
+        routes: Route<T, P>[],
+        entity: T | P
+    ) => {
+        return routes
+            .filter((route) => route.includes(entity))
+            .flat()
+            .filter((competingEntity) => competingEntity !== entity);
+    };
 
-const bigNumSum = (bigNumbers: BigNumber[]) =>
-    bigNumbers.reduce((sum, v) => sum.add(v), BigNumber.from(0));
-const bigNumMinBy = <T>(collection: T[], cb: (v: T) => BigNumber): T => {
-    return collection.reduce((smallest, current) => {
-        return cb(current).lt(cb(smallest)) ? current : smallest;
-    }, collection[0]);
-};
+    /**
+     * Create matches
+     */
+    const matchRound = <T extends Entity, P extends Entity>(
+        input: RoundInput<T, P>
+    ): Match<T, P>[] => {
+        const toDistribute = computeSafeDistribution(input.entityGroups[0], input.entityGroups[1]);
+
+        if (toDistribute.volume.eq(0)) {
+            const competingEntities = getCompetingEntities(input.routes, toDistribute.entity);
+
+            // We need to check to which group entity to distribute belongs
+            const isEntityFirst = input.entityGroups[0].find((e) => e === toDistribute.entity);
+
+            // Each competing entity will receive one volume from entity to distribute,
+            const entitiesToSatisfy = competingEntities.slice(
+                0,
+                toDistribute.entity.volume.toNumber()
+            );
+
+            return entitiesToSatisfy.map((connectedEntity) => ({
+                entities: (isEntityFirst
+                    ? [toDistribute.entity, connectedEntity]
+                    : [connectedEntity, toDistribute.entity]) as [T, P],
+                volume: BigNumber.from(1)
+            }));
+        }
+
+        return input.routes.map((route) => ({
+            entities: route,
+            volume: toDistribute.volume
+        }));
+    };
+
+    /**
+     * Return organized input for next matching round.
+     *
+     * It's purpose is to get first usable priority group (that has any volume),
+     * and for that, get first usable priority of second group (that has any volume),
+     * and make routes, that will be used for even spread.
+     */
+    const getRoundInput = <T extends Entity, P extends Entity>(
+        data: Params<T, P>
+    ): RoundInput<T, P> => {
+        const entity1Group = getFirstUsableGroup(data.groupPriority, data.entityGroups[0]);
+
+        const routes = entity1Group.flatMap((entity1GroupEntry) => {
+            const preferredEntity2Group = getFirstUsableGroup(
+                entity1GroupEntry.groupPriority,
+                data.entityGroups[1]
+            );
+
+            return cartesian(
+                entity1GroupEntry.entities,
+                preferredEntity2Group.flatMap((g) => g.entities)
+            );
+        });
+
+        return {
+            routes,
+            entityGroups: [
+                data.entityGroups[0].filter((entity) => routes.some((e) => e[0].id === entity.id)),
+                data.entityGroups[1].filter((entity) => routes.some((e) => e[1].id === entity.id))
+            ]
+        };
+    };
+
+    /**
+     * Given groups, and related entities with volumes
+     * it returns first group that has any volume left.
+     */
+    const getFirstUsableGroup = <T extends { id: string }, P extends Entity>(
+        groups: T[][],
+        entities: P[]
+    ): (T & { entities: P[] })[] => {
+        const entitiesWithVolume = entities.filter((e) => e.volume.gt(0));
+
+        const groupsWithVolume = groups
+            .map((group) => {
+                const entitiesInGroup = group.map((entry) => ({
+                    ...entry,
+                    entities: entitiesWithVolume.filter((e) => e.id === entry.id)
+                }));
+
+                return entitiesInGroup;
+            })
+            .filter((group) => group.some((g) => g.entities.length > 0));
+
+        return groupsWithVolume[0] ?? [];
+    };
+
+    const bigNumMinBy = <T>(collection: T[], cb: (v: T) => BigNumber): T => {
+        return collection.reduce((smallest, current) => {
+            return cb(current).lt(cb(smallest)) ? current : smallest;
+        }, collection[0]);
+    };
+
+    const cartesian = <T, P>(arr1: T[], arr2: P[]): [T, P][] => {
+        return arr1.flatMap((val1) => arr2.map((val2) => [val1, val2] as [T, P]));
+    };
+}

--- a/packages/origin-247-claim/tests/spreadMatcher.spec.ts
+++ b/packages/origin-247-claim/tests/spreadMatcher.spec.ts
@@ -1,19 +1,19 @@
 import { BigNumber } from 'ethers';
-import { spreadMatcher, SpreadMatcherData, SpreadMatcherEntity, SpreadMatcherResult } from '../src';
+import { SpreadMatcher } from '../src';
 
 describe('spreadMatcher', () => {
     describe('consumer priority', () => {
         it('2 consumers within same group - should distribute evenly between same priority consumers', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -31,19 +31,19 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(4);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 75
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 75
             });
 
@@ -70,15 +70,15 @@ describe('spreadMatcher', () => {
 
         it('2 consumers within same group - should distribute evenly between same priority consumers, regardless of consumptions', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -96,19 +96,19 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(4);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 75
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 75
             });
 
@@ -135,15 +135,15 @@ describe('spreadMatcher', () => {
 
         it('2 consumers within same group - should distribute one more to first consumer when generations are indivisible equally', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -161,19 +161,19 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(4);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 75
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 74
             });
 
@@ -200,19 +200,19 @@ describe('spreadMatcher', () => {
 
         it('3 consumers within same group - should distribute evenly between same priority consumers', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -231,27 +231,27 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(6);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 50
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 50
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerC', 'generatorA'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerC', 'generatorB'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorB' }],
                 volume: 50
             });
 
@@ -282,19 +282,19 @@ describe('spreadMatcher', () => {
 
         it('3 consumers within same group - should distribute last indivisible generation (1) to first consumer', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -313,27 +313,27 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(6);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 34
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 33
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 33
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 33
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerC', 'generatorA'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorA' }],
                 volume: 33
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerC', 'generatorB'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorB' }],
                 volume: 33
             });
 
@@ -364,19 +364,19 @@ describe('spreadMatcher', () => {
 
         it('3 consumers within same group - should distribute last indivisible generation (2) from different generators to first consumer', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -395,11 +395,11 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(6);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 34
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 34
             });
             // It's getting unequally distributed and provided to consumerA,
@@ -408,19 +408,19 @@ describe('spreadMatcher', () => {
             // and in case of 1 generation left - it's distributed to first consumer on list
 
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 33
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 33
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerC', 'generatorA'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorA' }],
                 volume: 33
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerC', 'generatorB'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorB' }],
                 volume: 33
             });
 
@@ -451,9 +451,19 @@ describe('spreadMatcher', () => {
 
         it('2 consumers within different groups - should satisfy higher priority group first', () => {
             const result = integerMatcher({
-                priority: [
-                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }],
-                    [{ id: 'consumerB', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                groupPriority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ],
+                    [
+                        {
+                            id: 'consumerB',
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
                 ],
                 entityGroups: [
                     [
@@ -469,19 +479,19 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(4);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 75
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 75
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 25
             });
 
@@ -509,25 +519,25 @@ describe('spreadMatcher', () => {
 
         it('2 consumer priority groups, 2 consumer each - should satisfy higher priority group first', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ],
                     [
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerD',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -547,35 +557,35 @@ describe('spreadMatcher', () => {
 
             // expect(result.matches).toHaveLength(4);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 50
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 50
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 50
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 50
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerC', 'generatorA'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerC', 'generatorB'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorB' }],
                 volume: 25
             });
             expect(result.matches[6]).toEqual({
-                entities: ['consumerD', 'generatorA'],
+                entities: [{ id: 'consumerD' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[7]).toEqual({
-                entities: ['consumerD', 'generatorB'],
+                entities: [{ id: 'consumerD' }, { id: 'generatorB' }],
                 volume: 25
             });
 
@@ -615,8 +625,13 @@ describe('spreadMatcher', () => {
     describe('generator priority', () => {
         it('2 generators - should distribute evenly between same priority generators', () => {
             const result = integerMatcher({
-                priority: [
-                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                groupPriority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
                 ],
                 entityGroups: [
                     [{ id: 'consumerA', volume: 100 }],
@@ -629,11 +644,11 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(2);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 50
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 50
             });
 
@@ -656,8 +671,13 @@ describe('spreadMatcher', () => {
 
         it('2 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
             const result = integerMatcher({
-                priority: [
-                    [{ id: 'consumerA', priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]] }]
+                groupPriority: [
+                    [
+                        {
+                            id: 'consumerA',
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                        }
+                    ]
                 ],
                 entityGroups: [
                     [{ id: 'consumerA', volume: 51 }],
@@ -669,22 +689,22 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 26
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 25
             });
         });
 
         it('3 generators - should distribute evenly between same priority generators', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [
+                            groupPriority: [
                                 [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
                             ]
                         }
@@ -702,15 +722,15 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(3);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 40
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 40
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerA', 'generatorC'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorC' }],
                 volume: 40
             });
 
@@ -737,11 +757,11 @@ describe('spreadMatcher', () => {
 
         it('3 generators - should distribute last indivisible consumption (1) from first generation on list', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [
+                            groupPriority: [
                                 [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
                             ]
                         }
@@ -758,15 +778,15 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 34
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 33
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerA', 'generatorC'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorC' }],
                 volume: 33
             });
 
@@ -793,11 +813,11 @@ describe('spreadMatcher', () => {
 
         it('3 generators - should distribute last indivisible consumption (2) from first two generations on list', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [
+                            groupPriority: [
                                 [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
                             ]
                         }
@@ -814,15 +834,15 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 34
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 34
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerA', 'generatorC'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorC' }],
                 volume: 33
             });
 
@@ -849,15 +869,15 @@ describe('spreadMatcher', () => {
 
         it('2 generators and 2 consumers - should distribute evenly between same priority generators', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -874,36 +894,36 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 25
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 25
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 25
             });
         });
 
         it('3 generators and 2 consumers - should distribute evenly between same priority generators', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [
+                            groupPriority: [
                                 [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
                             ]
                         },
                         {
                             id: 'consumerB',
-                            priority: [
+                            groupPriority: [
                                 [{ id: 'generatorA' }, { id: 'generatorB' }, { id: 'generatorC' }]
                             ]
                         }
@@ -923,46 +943,46 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 10
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 10
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerA', 'generatorC'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorC' }],
                 volume: 10
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 10
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 10
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerB', 'generatorC'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorC' }],
                 volume: 10
             });
         });
 
         it('2 generators and 3 consumers - should distribute evenly between same priority generators', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -980,27 +1000,27 @@ describe('spreadMatcher', () => {
             });
 
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 5
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerA', 'generatorB'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorB' }],
                 volume: 5
             });
             expect(result.matches[2]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 5
             });
             expect(result.matches[3]).toEqual({
-                entities: ['consumerB', 'generatorB'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorB' }],
                 volume: 5
             });
             expect(result.matches[4]).toEqual({
-                entities: ['consumerC', 'generatorA'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorA' }],
                 volume: 5
             });
             expect(result.matches[5]).toEqual({
-                entities: ['consumerC', 'generatorB'],
+                entities: [{ id: 'consumerC' }, { id: 'generatorB' }],
                 volume: 5
             });
 
@@ -1020,19 +1040,19 @@ describe('spreadMatcher', () => {
     describe('leftover consumptions', () => {
         it('should return only leftover consumptions when there are no generations', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerC',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -1063,10 +1083,10 @@ describe('spreadMatcher', () => {
 
         it('should return leftover consumptions when the generations cannot satisfy all consumptions', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
-                        { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
-                        { id: 'consumerB', priority: [[{ id: 'generatorA' }]] }
+                        { id: 'consumerA', groupPriority: [[{ id: 'generatorA' }]] },
+                        { id: 'consumerB', groupPriority: [[{ id: 'generatorA' }]] }
                     ]
                 ],
                 entityGroups: [
@@ -1080,11 +1100,11 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(2);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 5
             });
             expect(result.matches[1]).toEqual({
-                entities: ['consumerB', 'generatorA'],
+                entities: [{ id: 'consumerB' }, { id: 'generatorA' }],
                 volume: 5
             });
 
@@ -1103,15 +1123,15 @@ describe('spreadMatcher', () => {
     describe('excess generations', () => {
         it('should return only excess generations when there are no consumptions to satisfy', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
                         {
                             id: 'consumerA',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         },
                         {
                             id: 'consumerB',
-                            priority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
+                            groupPriority: [[{ id: 'generatorA' }, { id: 'generatorB' }]]
                         }
                     ]
                 ],
@@ -1129,10 +1149,10 @@ describe('spreadMatcher', () => {
 
         it('should return excess generations when the consumptions are satisfied and there are generations left', () => {
             const result = integerMatcher({
-                priority: [
+                groupPriority: [
                     [
-                        { id: 'consumerA', priority: [[{ id: 'generatorA' }]] },
-                        { id: 'consumerB', priority: [[{ id: 'generatorA' }]] }
+                        { id: 'consumerA', groupPriority: [[{ id: 'generatorA' }]] },
+                        { id: 'consumerB', groupPriority: [[{ id: 'generatorA' }]] }
                     ]
                 ],
                 entityGroups: [[{ id: 'consumerA', volume: 5 }], [{ id: 'generatorA', volume: 10 }]]
@@ -1140,7 +1160,7 @@ describe('spreadMatcher', () => {
 
             expect(result.matches).toHaveLength(1);
             expect(result.matches[0]).toEqual({
-                entities: ['consumerA', 'generatorA'],
+                entities: [{ id: 'consumerA' }, { id: 'generatorA' }],
                 volume: 5
             });
 
@@ -1151,6 +1171,32 @@ describe('spreadMatcher', () => {
             });
         });
         // excess generations end
+    });
+
+    describe('Custom data', () => {
+        it('returns entities custom data in match result', () => {
+            const result = SpreadMatcher.spreadMatcher({
+                groupPriority: [
+                    [
+                        { id: 'consumerA', groupPriority: [[{ id: 'generatorA' }]] },
+                        { id: 'consumerB', groupPriority: [[{ id: 'generatorA' }]] }
+                    ]
+                ],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: BigNumber.from(5), type: 'consumer' }],
+                    [{ id: 'generatorA', volume: BigNumber.from(10), type: 'generator' }]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(1);
+            expect(result.matches[0]).toEqual({
+                entities: [
+                    { id: 'consumerA', type: 'consumer' },
+                    { id: 'generatorA', type: 'generator' }
+                ],
+                volume: BigNumber.from(5)
+            });
+        });
     });
     // Matching algorithm end
 });
@@ -1164,17 +1210,17 @@ type IntegerVolume<T> = {
         : IntegerVolume<T[K]>;
 };
 
-const integerMatcher = (
-    params: IntegerVolume<SpreadMatcherData>
-): IntegerVolume<SpreadMatcherResult> => {
-    const result = spreadMatcher({
-        priority: params.priority,
+const integerMatcher = <T extends SpreadMatcher.Entity, P extends SpreadMatcher.Entity>(
+    params: IntegerVolume<SpreadMatcher.Params<T, P>>
+): IntegerVolume<SpreadMatcher.Result<T, P>> => {
+    const result = SpreadMatcher.spreadMatcher({
+        groupPriority: params.groupPriority,
         entityGroups: params.entityGroups.map((g) =>
             g.map((e) => ({
                 id: e.id,
                 volume: BigNumber.from(e.volume)
             }))
-        ) as [SpreadMatcherEntity[], SpreadMatcherEntity[]]
+        ) as [SpreadMatcher.Entity[], SpreadMatcher.Entity[]]
     });
 
     return {
@@ -1187,6 +1233,6 @@ const integerMatcher = (
         matches: result.matches.map((m) => ({
             ...m,
             volume: m.volume.toNumber()
-        }))
+        })) as any
     };
 };


### PR DESCRIPTION
BREAKING CHANGE: result returned from matcher now is built of entities with all their fields, instead of entities id
BREAKING CHANGE: changed API: now instead of "priority" there is "groupPriority" field
BREAKING CHANGE: export from algorithm is wrapped in SpreadMatcher namespace