### PR TITLE
feat(origin-247-claim): allow missing entity priority

### DIFF
--- a/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
+++ b/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
@@ -86,7 +86,16 @@ export namespace SpreadMatcher {
                 break;
             }
 
-            const roundMatches = matchRound(getRoundInput(data));
+            const roundInput = getRoundInput(data);
+
+            // No routes can be computed
+            // if there is some consumption/generation left,
+            // but it won't be used because of missing priorities
+            if (roundInput.routes.length === 0) {
+                break;
+            }
+
+            const roundMatches = matchRound(roundInput);
 
             roundMatches.forEach((match) => {
                 const entity1 = data.entityGroups[0].find((e) => e === match.entities[0])!;

--- a/packages/origin-247-claim/tests/spreadMatcher.spec.ts
+++ b/packages/origin-247-claim/tests/spreadMatcher.spec.ts
@@ -1249,7 +1249,20 @@ describe('spreadMatcher', () => {
             });
         });
     });
-    // Matching algorithm end
+
+    describe('Missing generator priorities', () => {
+        it('Skips generators not in group', () => {
+            const result = SpreadMatcher.spreadMatcher({
+                groupPriority: [[{ id: 'consumerA', groupPriority: [[{ id: 'generatorA' }]] }]],
+                entityGroups: [
+                    [{ id: 'consumerA', volume: BigNumber.from(50) }],
+                    [{ id: 'generatorB', volume: BigNumber.from(30) }]
+                ]
+            });
+
+            expect(result.matches).toHaveLength(0);
+        });
+    });
 });
 
 type Primitive = string | number | boolean | undefined | null;


### PR DESCRIPTION
Now spreadMatcher algorithm doesn't require to pass all required priorities (requirement from one of the clients) - this way there will be more leftovers, since some generators won't be used