### PR TITLE
Chore/aggregate optimization

### DIFF
--- a/packages/origin-247-claim/src/utils/Duration.ts
+++ b/packages/origin-247-claim/src/utils/Duration.ts
@@ -64,11 +64,16 @@ export class Duration {
 
     public roundDateUp(dateToRound: Date): number {
         switch (this.durationUnit) {
+            // in case of month, we don't want to increment if it happens to be the beggining of the month
+            // otherwise, we want to take the start of next month
             case 'mo': {
                 const luxonDate = DateTime.fromJSDate(dateToRound);
                 return luxonDate.equals(luxonDate.startOf('month'))
                     ? luxonDate.toMillis()
-                    : DateTime.fromJSDate(dateToRound).endOf('month').toMillis() + 1;
+                    : DateTime.fromJSDate(dateToRound)
+                          .plus({ month: 1 })
+                          .startOf('month')
+                          .toMillis();
             }
             case 'y':
                 return DateTime.fromJSDate(dateToRound)

--- a/packages/origin-247-claim/src/utils/Duration.ts
+++ b/packages/origin-247-claim/src/utils/Duration.ts
@@ -1,4 +1,5 @@
 import { DateTime, Duration as luxDuration, DurationObject } from 'luxon';
+import { start } from 'repl';
 
 /**
  * Treats month as 30 days
@@ -64,11 +65,12 @@ export class Duration {
 
     public roundDateUp(dateToRound: Date): number {
         switch (this.durationUnit) {
-            case 'mo':
-                return DateTime.fromJSDate(dateToRound)
-                    .startOf('month')
-                    .plus({ month: 1 })
-                    .toMillis();
+            case 'mo': {
+                const luxonDate = DateTime.fromJSDate(dateToRound);
+                return luxonDate.equals(luxonDate.startOf('month'))
+                    ? luxonDate.toMillis()
+                    : DateTime.fromJSDate(dateToRound).endOf('month').toMillis() + 1;
+            }
             case 'y':
                 return DateTime.fromJSDate(dateToRound)
                     .startOf('year')

--- a/packages/origin-247-claim/src/utils/Duration.ts
+++ b/packages/origin-247-claim/src/utils/Duration.ts
@@ -1,5 +1,4 @@
 import { DateTime, Duration as luxDuration, DurationObject } from 'luxon';
-import { start } from 'repl';
 
 /**
  * Treats month as 30 days

--- a/packages/origin-247-claim/src/utils/Duration.ts
+++ b/packages/origin-247-claim/src/utils/Duration.ts
@@ -58,12 +58,38 @@ export class Duration {
         }
     }
 
+    public getDurationUnit() {
+        return this.durationUnit;
+    }
+
+    public roundDateUp(dateToRound: Date): number {
+        switch (this.durationUnit) {
+            case 'mo':
+                return DateTime.fromJSDate(dateToRound)
+                    .startOf('month')
+                    .plus({ month: 1 })
+                    .toMillis();
+            case 'y':
+                return DateTime.fromJSDate(dateToRound)
+                    .startOf('year')
+                    .plus({ year: 1 })
+                    .toMillis();
+            default:
+                return this.roundToClosestUpper(dateToRound);
+        }
+    }
+
     public static readonly durationValidationRegex = /(^(\d+)(m|h|d|w)$)|(^(1)(mo|y)$)/;
     private static readonly durationRegex = /^(?<value>\d+)(?<unit>m|h|d|w|mo|y)$/;
 
     private roundToClosestLower(dateToRound: Date): number {
         const toClosest = this.getMilliSeconds();
         return Math.floor(dateToRound.getTime() / toClosest) * toClosest;
+    }
+
+    private roundToClosestUpper(dateToRound: Date): number {
+        const toClosest = this.getMilliSeconds();
+        return Math.ceil(dateToRound.getTime() / toClosest) * toClosest;
     }
 }
 

--- a/packages/origin-247-claim/src/utils/aggregate.spec.ts
+++ b/packages/origin-247-claim/src/utils/aggregate.spec.ts
@@ -95,7 +95,7 @@ describe('aggregate function', () => {
             start: new Date('2021-05-13T08:00:00.000Z'),
             end: new Date('2021-07-15T10:00:00.000Z'),
             method: AggregateMethod.Sum,
-            window: new Duration('30d'),
+            window: new Duration('1mo'),
             timezoneOffset: 0
         };
         const aggregated = aggregate({

--- a/packages/origin-247-claim/src/utils/aggregate.ts
+++ b/packages/origin-247-claim/src/utils/aggregate.ts
@@ -93,19 +93,20 @@ export const aggregate = ({
         ? offsettedCommand.data.filter((d) => d.time > offsettedCommand.start!)
         : offsettedCommand.data;
 
-    const groupedByInterval = new Map<string, BigNumber[]>();
+    const groupedByInterval: Record<string, BigNumber[]> = {};
     dataset.forEach((d) => {
         const roundedDate = new Date(window.roundDateUp(d.time));
-        const exists = groupedByInterval.get(roundedDate.toISOString());
+        const stringifiedDate = roundedDate.toISOString();
+        const exists = groupedByInterval[stringifiedDate];
         exists
-            ? groupedByInterval.set(roundedDate.toISOString(), [...exists, d.value])
-            : groupedByInterval.set(roundedDate.toISOString(), [d.value]);
+            ? (groupedByInterval[stringifiedDate] = [...exists, d.value])
+            : (groupedByInterval[stringifiedDate] = [d.value]);
     });
 
     const intervals = buildAggregateFrames(offsettedCommand);
     const result = intervals.map((interval) => {
         const dateKey = new Date(window.roundDateUp(interval.end));
-        const exists = groupedByInterval.get(dateKey.toISOString());
+        const exists = groupedByInterval[dateKey.toISOString()];
         const value = exists ? aggregateFunction(exists) : BigNumber.from(0);
         return {
             start: interval.start,

--- a/packages/origin-247-claim/src/utils/aggregate.ts
+++ b/packages/origin-247-claim/src/utils/aggregate.ts
@@ -89,9 +89,12 @@ export const aggregate = ({
         end,
         timezoneOffset
     });
+    const dataset = start
+        ? offsettedCommand.data.filter((d) => d.time > offsettedCommand.start!)
+        : offsettedCommand.data;
 
     const groupedByInterval = new Map<string, BigNumber[]>();
-    offsettedCommand.data.forEach((d) => {
+    dataset.forEach((d) => {
         const roundedDate = new Date(window.roundDateUp(d.time));
         const exists = groupedByInterval.get(roundedDate.toISOString());
         exists
@@ -101,10 +104,7 @@ export const aggregate = ({
 
     const intervals = buildAggregateFrames(offsettedCommand);
     const result = intervals.map((interval) => {
-        const dateKey =
-            window.getDurationUnit() === 'mo'
-                ? interval.end
-                : new Date(window.roundDateUp(interval.end));
+        const dateKey = new Date(window.roundDateUp(interval.end));
         const exists = groupedByInterval.get(dateKey.toISOString());
         const value = exists ? aggregateFunction(exists) : BigNumber.from(0);
         return {
@@ -113,6 +113,5 @@ export const aggregate = ({
             value: value
         };
     });
-
     return result;
 };


### PR DESCRIPTION
Task:
When querying the data to display long timeframes (huge data sets) on the UI it takes a long time:
  1. Check the endpoints and try to find out where we could be faster. 
  2. Tables to take a look at
  
  
  ----
Checked the endpoints and saw that the aggregate function is the biggest bottleneck.
  