### PR TITLE
fix: use sequence for generating internal certificate id

### DIFF
--- a/packages/origin-247-certificate/migrations/1643115428770-AddInternalCertificateIdSequence.ts
+++ b/packages/origin-247-certificate/migrations/1643115428770-AddInternalCertificateIdSequence.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export const sequenceName = 'certificate_internal_certificate_id_seq';
+
+export class AddInternalCertificateIdSequence1643115428770 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE SEQUENCE IF NOT EXISTS ${sequenceName}`);
+
+        const [{ count }] = await queryRunner.query(
+            `SELECT COUNT(*) FROM certificate_event WHERE type = 'Issued'`
+        );
+
+        if (Number(count) === 0) {
+            await queryRunner.query(`ALTER SEQUENCE ${sequenceName} RESTART`);
+        } else {
+            await queryRunner.query(`ALTER SEQUENCE ${sequenceName} RESTART ${Number(count) + 1}`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP SEQUENCE ${sequenceName}`);
+    }
+}

--- a/packages/origin-247-certificate/src/offchain-certificate/offchain-certificate.service.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/offchain-certificate.service.ts
@@ -233,8 +233,7 @@ export class OffChainCertificateService<T = null> {
     }
 
     private async generateInternalCertificateId(): Promise<number> {
-        const numberOfCertificates = await this.certEventRepo.getNumberOfCertificates();
-        return numberOfCertificates + 1;
+        return await this.certEventRepo.getNextInternalCertificateId();
     }
 
     private async propagate(

--- a/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEvent.repository.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEvent.repository.ts
@@ -32,7 +32,7 @@ export interface CertificateEventRepository {
 
     getAll(): Promise<ICertificateEvent[]>;
 
-    getNumberOfCertificates(): Promise<number>;
+    getNextInternalCertificateId(): Promise<number>;
 
     findAllToProcess(options: IGetToProcessOptions): Promise<ICertificateEvent[]>;
 }

--- a/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventInMemory.repository.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventInMemory.repository.ts
@@ -13,6 +13,7 @@ import { chain } from 'lodash';
 
 @Injectable()
 export class CertificateEventInMemoryRepository implements CertificateEventRepository {
+    private internalCertificateIdSerial: number = 0;
     private eventDb: CertificateEventEntity[] = [];
     private attemptDb: Record<string, CertificateSynchronizationAttemptEntity> = {};
     private maxSynchronizationAttemptsForEvent: number = Infinity;
@@ -131,7 +132,9 @@ export class CertificateEventInMemoryRepository implements CertificateEventRepos
         return idMap;
     }
 
-    public async getNumberOfCertificates(): Promise<number> {
-        return this.eventDb.filter((e) => e.type === CertificateEventType.Issued).length;
+    public async getNextInternalCertificateId(): Promise<number> {
+        this.internalCertificateIdSerial += 1;
+
+        return this.internalCertificateIdSerial;
     }
 }

--- a/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventPostgres.repository.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventPostgres.repository.ts
@@ -169,13 +169,11 @@ export class CertificateEventPostgresRepository implements CertificateEventRepos
         );
     }
 
-    public async getNumberOfCertificates(): Promise<number> {
-        const [certs, count] = await this.repository.findAndCount({
-            where: {
-                type: CertificateEventType.Issued
-            }
-        });
+    public async getNextInternalCertificateId(): Promise<number> {
+        const [{ nextval }] = await this.repository.query(
+            `SELECT nextval('certificate_internal_certificate_id_seq')`
+        );
 
-        return count;
+        return Number(nextval);
     }
 }

--- a/packages/origin-247-certificate/test/offchain-certificate/certificateEventRepository.e2e-spec.ts
+++ b/packages/origin-247-certificate/test/offchain-certificate/certificateEventRepository.e2e-spec.ts
@@ -99,46 +99,10 @@ describe('CertificateEventRepository', () => {
         expect(certs).toHaveLength(2);
     });
 
-    it('should return the number of issued certificates', async () => {
-        let issuedCerts = await certificateEventRepository.getNumberOfCertificates();
-        expect(issuedCerts).toBe(0);
-
-        const event = CertificateIssuedEvent.createNew(issuedCerts + 1, {
-            toAddress: '0x1',
-            toTime: new Date().getTime(),
-            fromTime: new Date().getTime(),
-            energyValue: '100',
-            userId: 'user1',
-            deviceId: 'asdf',
-            metadata: {}
-        });
-        await certificateEventService.save(event, 1);
-        issuedCerts = await certificateEventRepository.getNumberOfCertificates();
-        expect(issuedCerts).toBe(1);
-
-        const otherEvent = CertificateTransferredEvent.createNew(1, {
-            toAddress: '0x1',
-            certificateId: 1,
-            energyValue: '100',
-            fromAddress: '0x2'
-        });
-        await certificateEventService.save(otherEvent, 2);
-
-        issuedCerts = await certificateEventRepository.getNumberOfCertificates();
-        expect(issuedCerts).toBe(1);
-
-        const anotherEvent = CertificateIssuedEvent.createNew(issuedCerts + 1, {
-            toAddress: '0x1',
-            toTime: new Date().getTime(),
-            fromTime: new Date().getTime(),
-            energyValue: '100',
-            userId: 'user1',
-            deviceId: 'asdf',
-            metadata: {}
-        });
-        await certificateEventService.save(anotherEvent, 3);
-        issuedCerts = await certificateEventRepository.getNumberOfCertificates();
-        expect(issuedCerts).toBe(2);
+    it('should return corrent next internal certificate id', async () => {
+        expect(await certificateEventRepository.getNextInternalCertificateId()).toBe(2);
+        expect(await certificateEventRepository.getNextInternalCertificateId()).toBe(3);
+        expect(await certificateEventRepository.getNextInternalCertificateId()).toBe(4);
     });
 
     describe('#findAllToProcess', () => {

--- a/packages/origin-247-certificate/test/setup.ts
+++ b/packages/origin-247-certificate/test/setup.ts
@@ -125,6 +125,13 @@ export const bootstrapTestInstance: any = async () => {
 
     const cleanDB = async () => {
         await connection.query(`TRUNCATE ${tables} RESTART IDENTITY CASCADE;`);
+        // Restart all sequences
+        await connection.query(`
+            SELECT  SETVAL(c.oid, 1)
+            from pg_class c JOIN pg_namespace n 
+            on n.oid = c.relnamespace 
+            where c.relkind = 'S' and n.nspname = 'public'  
+        `);
     };
 
     const blockchainProperties = await blockchainPropertiesService.create(

--- a/packages/origin-247-transfer/test/transfer.e2e-spec.ts
+++ b/packages/origin-247-transfer/test/transfer.e2e-spec.ts
@@ -18,9 +18,8 @@ describe('Transfer module - e2e', () => {
 
         const etr = (await repository.findById(1))!;
         const etrAttrs = etr.toAttrs();
-        const certificate = (await certificateService.getById(1))!;
+        const certificate = (await certificateService.getById(etr.certificateId!))!;
 
-        expect(etrAttrs.certificateId).toBe(1);
         expect(etrAttrs.state).toBe(State.Transferred);
         expect(etrAttrs.buyerAddress).toBe('0xeF99b2A55E6D070bA2D12f79b368148BF7d6Fc10');
         expect(etrAttrs.sellerAddress).toBe('0x212fb883109dC887a605B09078E219Db75e5AAc7');
@@ -34,9 +33,8 @@ describe('Transfer module - e2e', () => {
 
         const etr2 = (await repository.findById(2))!;
         const etr2Attrs = etr2.toAttrs();
-        const certificate2 = (await certificateService.getById(2))!;
+        const certificate2 = (await certificateService.getById(etr2.certificateId!))!;
 
-        expect(etr2Attrs.certificateId).toBe(2);
         expect(etr2Attrs.state).toBe(State.Transferred);
         expect(etr2Attrs.buyerAddress).toBe('0xeF99b2A55E6D070bA2D12f79b368148BF7d6Fc10');
         expect(etr2Attrs.sellerAddress).toBe('0x212fb883109dC887a605B09078E219Db75e5AAc7');


### PR DESCRIPTION
Reason for change: it is impossible to migrate existing environment.

Internal certificate id gets generated as `1`, and this conflicts in `ETR` table with certificates generated from onchain implementation.

This way client can create migration to set sequence manually