### PR TITLE
feat: Add namespaced config for certificate module

### DIFF
--- a/packages/origin-247-certificate/ormconfig-dev.ts
+++ b/packages/origin-247-certificate/ormconfig-dev.ts
@@ -1,5 +1,5 @@
 import { ConnectionOptions } from 'typeorm';
-import getConfiguration from './src/offchain-certificate/config/configuration';
+import { getConfiguration } from './src/config/configuration';
 
 const getDBConnectionOptions = (): ConnectionOptions => {
     const configuration = getConfiguration();

--- a/packages/origin-247-certificate/ormconfig.ts
+++ b/packages/origin-247-certificate/ormconfig.ts
@@ -1,5 +1,5 @@
 import { ConnectionOptions } from 'typeorm';
-import getConfiguration from './src/offchain-certificate/config/configuration';
+import { getConfiguration } from './src/config/configuration';
 
 const getDBConnectionOptions = (): ConnectionOptions => {
     const configuration = getConfiguration();

--- a/packages/origin-247-certificate/src/config/certificate-config.module.ts
+++ b/packages/origin-247-certificate/src/config/certificate-config.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import {
+    CertificateConfigService,
+    registerNamespacedConfiguration
+} from './certificate-config.service';
+
+@Global()
+@Module({
+    providers: [CertificateConfigService],
+    exports: [CertificateConfigService],
+    imports: [ConfigModule.forFeature(registerNamespacedConfiguration)]
+})
+export class CertificateConfigModule {}

--- a/packages/origin-247-certificate/src/config/certificate-config.service.ts
+++ b/packages/origin-247-certificate/src/config/certificate-config.service.ts
@@ -1,0 +1,23 @@
+import { ConfigService, registerAs } from '@nestjs/config';
+import { Injectable } from '@nestjs/common';
+import { getConfiguration } from './configuration';
+import { CERTIFICATE_247_NAMESPACE, Configuration } from './config.interface';
+
+@Injectable()
+export class CertificateConfigService {
+    constructor(private configService: ConfigService) {}
+
+    public get<T = string>(key: keyof Configuration): T {
+        return this.configService.get(namespaced(key))!;
+    }
+}
+
+type NamespacedKey = `${typeof CERTIFICATE_247_NAMESPACE}.${keyof Configuration}`;
+
+const namespaced = (key: keyof Configuration): NamespacedKey =>
+    `${CERTIFICATE_247_NAMESPACE}.${key}`;
+
+export const registerNamespacedConfiguration = registerAs(
+    CERTIFICATE_247_NAMESPACE,
+    getConfiguration
+);

--- a/packages/origin-247-certificate/src/config/config.interface.ts
+++ b/packages/origin-247-certificate/src/config/config.interface.ts
@@ -1,3 +1,5 @@
+export const CERTIFICATE_247_NAMESPACE = 'origin-247-certificate-config';
+
 export interface Configuration {
     DATABASE_URL?: string;
     DB_HOST: string;
@@ -5,9 +7,9 @@ export interface Configuration {
     DB_USERNAME: string;
     DB_PASSWORD: string;
     DB_DATABASE: string;
+    REDIS_URL: string | { host: string; port: number };
     CERTIFICATE_QUEUE_DELAY: number;
     CERTIFICATE_QUEUE_LOCK_DURATION: number;
-    REDIS_URL: string | { host: string; port: number };
     MAX_SYNCHRONIZATION_ATTEMPTS_FOR_EVENT: number;
     ISSUE_BATCH_SIZE: number;
     TRANSFER_BATCH_SIZE: number;

--- a/packages/origin-247-certificate/src/config/configuration.ts
+++ b/packages/origin-247-certificate/src/config/configuration.ts
@@ -1,17 +1,17 @@
 import { Configuration } from './config.interface';
 
-const getConfiguration = (): Configuration => ({
+export const getConfiguration = (): Configuration => ({
     DATABASE_URL: process.env.DATABASE_URL,
     DB_HOST: process.env.DB_HOST ?? 'localhost',
     DB_PORT: Number(process.env.DB_PORT ?? 5432),
     DB_USERNAME: process.env.DB_USERNAME ?? 'postgres',
     DB_PASSWORD: process.env.DB_PASSWORD ?? 'postgres',
     DB_DATABASE: process.env.DB_DATABASE ?? 'origin',
+    REDIS_URL: process.env.REDIS_URL ?? { host: 'localhost', port: 6379 },
     CERTIFICATE_QUEUE_DELAY: Number(process.env.CERTIFICATE_QUEUE_DELAY) ?? 10000,
     CERTIFICATE_QUEUE_LOCK_DURATION: Number(
         process.env.CERTIFICATE_QUEUE_LOCK_DURATION ?? 240 * 1000
     ),
-    REDIS_URL: process.env.REDIS_URL ?? { host: 'localhost', port: 6379 },
     MAX_SYNCHRONIZATION_ATTEMPTS_FOR_EVENT: process.env.MAX_SYNCHRONIZATION_ATTEMPTS_FOR_EVENT
         ? Number(process.env.MAX_SYNCHRONIZATION_ATTEMPTS_FOR_EVENT)
         : 3,
@@ -21,5 +21,3 @@ const getConfiguration = (): Configuration => ({
         ? parseInt(process.env.TRANSFER_BATCH_SIZE)
         : 100
 });
-
-export default getConfiguration;

--- a/packages/origin-247-certificate/src/offchain-certificate/offchain-certificate.module.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/offchain-certificate.module.ts
@@ -40,8 +40,7 @@ import { ENTITY_MANAGER, InMemoryEntityManager } from './utils/entity-manager';
 import { EntityManager } from 'typeorm';
 import { BlockchainSynchronizeQueuedService } from './synchronize/blockchain-synchronize-queued.service';
 import { BlockchainSynchronizeSyncService } from './synchronize/blockchain-synchronize-sync.service';
-import { ConfigModule } from '@nestjs/config';
-import getConfiguration from './config/configuration';
+import { CertificateConfigModule } from '../config/certificate-config.module';
 
 @Module({
     providers: [
@@ -94,10 +93,7 @@ import getConfiguration from './config/configuration';
         BullModule.registerQueue({
             name: SYNCHRONIZE_QUEUE_NAME
         }),
-        ConfigModule.forRoot({
-            load: [getConfiguration]
-            // isGlobal: true
-        })
+        CertificateConfigModule
     ]
 })
 export class OffChainCertificateModule {}

--- a/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventPostgres.repository.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/repositories/CertificateEvent/CertificateEventPostgres.repository.ts
@@ -10,8 +10,7 @@ import {
     ICertificateEvent
 } from '../../events/Certificate.events';
 import { CertificateSynchronizationAttemptEntity } from './CertificateSynchronizationAttempt.entity';
-import { ConfigService } from '@nestjs/config';
-import { Configuration } from '../../config/config.interface';
+import { CertificateConfigService } from '../../../config/certificate-config.service';
 
 @Injectable()
 export class CertificateEventPostgresRepository implements CertificateEventRepository {
@@ -22,9 +21,9 @@ export class CertificateEventPostgresRepository implements CertificateEventRepos
         private repository: Repository<CertificateEventEntity>,
         @InjectRepository(CertificateSynchronizationAttemptEntity)
         private synchronizationAttemptRepository: Repository<CertificateSynchronizationAttemptEntity>,
-        configService: ConfigService<Configuration>
+        private certificateConfigService: CertificateConfigService
     ) {
-        this.maxSynchronizationAttemptsForEvent = configService.get(
+        this.maxSynchronizationAttemptsForEvent = certificateConfigService.get(
             'MAX_SYNCHRONIZATION_ATTEMPTS_FOR_EVENT'
         )!;
     }

--- a/packages/origin-247-certificate/src/offchain-certificate/synchronize/strategies/batch/batch.configuration.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/synchronize/strategies/batch/batch.configuration.ts
@@ -1,5 +1,5 @@
-import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
+import { CertificateConfigService } from '../../../../config/certificate-config.service';
 
 export interface BatchConfiguration {
     issueBatchSize: number;
@@ -11,17 +11,15 @@ export const BATCH_CONFIGURATION_TOKEN = Symbol.for('BATCH_CONFIGURATION_TOKEN')
 
 @Injectable()
 export class BatchConfigurationService {
-    constructor(private configService: ConfigService) {}
+    constructor(private certificateConfigService: CertificateConfigService) {}
 
     getBatchSizes(): BatchConfiguration {
-        const issueSize = this.configService.get('ISSUE_BATCH_SIZE');
-        const claimSize = this.configService.get('CLAIM_BATCH_SIZE');
-        const transferSize = this.configService.get('TRANSFER_BATCH_SIZE');
-
         return {
-            issueBatchSize: issueSize ? parseInt(issueSize) : 10,
-            claimBatchSize: claimSize ? parseInt(claimSize) : 25,
-            transferBatchSize: transferSize ? parseInt(transferSize) : 100
+            // These variable and default values are properly handled by ConfigModule,
+            // but version 1.0.2 of `@nestjs/config` doesn't allow to infer the type as `number`
+            issueBatchSize: this.certificateConfigService.get('ISSUE_BATCH_SIZE'),
+            claimBatchSize: this.certificateConfigService.get('CLAIM_BATCH_SIZE'),
+            transferBatchSize: this.certificateConfigService.get('TRANSFER_BATCH_SIZE')
         };
     }
 }

--- a/packages/origin-247-certificate/src/offchain-certificate/synchronize/strategies/batch/batch.configuration.ts
+++ b/packages/origin-247-certificate/src/offchain-certificate/synchronize/strategies/batch/batch.configuration.ts
@@ -15,8 +15,6 @@ export class BatchConfigurationService {
 
     getBatchSizes(): BatchConfiguration {
         return {
-            // These variable and default values are properly handled by ConfigModule,
-            // but version 1.0.2 of `@nestjs/config` doesn't allow to infer the type as `number`
             issueBatchSize: this.certificateConfigService.get('ISSUE_BATCH_SIZE'),
             claimBatchSize: this.certificateConfigService.get('CLAIM_BATCH_SIZE'),
             transferBatchSize: this.certificateConfigService.get('TRANSFER_BATCH_SIZE')

--- a/packages/origin-247-certificate/src/onchain-certificate/blockchain-actions.processor.ts
+++ b/packages/origin-247-certificate/src/onchain-certificate/blockchain-actions.processor.ts
@@ -2,9 +2,8 @@ import { Process, Processor } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 import { BlockchainAction } from './types';
-import { ConfigService } from '@nestjs/config';
-import { Configuration } from '../offchain-certificate/config/config.interface';
 import { CertificateOperationsService } from './certificate-operations/certificate-operations.service';
+import { CertificateConfigService } from '../config/certificate-config.service';
 
 export const blockchainQueueName = 'blockchain-actions';
 
@@ -13,7 +12,7 @@ export class BlockchainActionsProcessor {
     private readonly logger = new Logger(BlockchainActionsProcessor.name);
 
     constructor(
-        private readonly configService: ConfigService<Configuration>,
+        private readonly certificateConfigService: CertificateConfigService,
         private readonly certificateOperationsFacade: CertificateOperationsService
     ) {}
 
@@ -27,7 +26,7 @@ export class BlockchainActionsProcessor {
              * Therefore we need to give some time to process everything.
              */
             await new Promise((resolve) =>
-                setTimeout(resolve, this.configService.get('CERTIFICATE_QUEUE_DELAY'))
+                setTimeout(resolve, this.certificateConfigService.get('CERTIFICATE_QUEUE_DELAY'))
             );
 
             return result;

--- a/packages/origin-247-certificate/src/onchain-certificate/listeners/on-chain-certificates.listener.ts
+++ b/packages/origin-247-certificate/src/onchain-certificate/listeners/on-chain-certificates.listener.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { providers } from 'ethers';
 import { CertificateUtils, IBlockchainProperties } from '@energyweb/issuer';
 import { ConfigService } from '@nestjs/config';

--- a/packages/origin-247-certificate/src/onchain-certificate/onchain-certificate.module.ts
+++ b/packages/origin-247-certificate/src/onchain-certificate/onchain-certificate.module.ts
@@ -6,9 +6,6 @@ import { CertificateForUnitTestsService } from './onchain-certificateForUnitTest
 import { OnChainCertificateService } from './onchain-certificate.service';
 import { BlockchainActionsProcessor, blockchainQueueName } from './blockchain-actions.processor';
 import { ONCHAIN_CERTIFICATE_SERVICE_TOKEN } from './types';
-import getConfiguration from '../offchain-certificate/config/configuration';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { Configuration } from '../offchain-certificate/config/config.interface';
 import { BlockchainPropertiesService } from './blockchain-properties.service';
 import { OnChainCertificateFacade } from './onChainCertificateFacade';
 import { DeploymentPropertiesRepository } from './repositories/deploymentProperties/deploymentProperties.repository';
@@ -27,6 +24,8 @@ import { CertificateReadModelInMemoryRepository } from '../offchain-certificate/
 import { CertificateReadModelPostgresRepository } from '../offchain-certificate/repositories/CertificateReadModel/CertificateReadModelPostgres.repository';
 import { CertificateReadModelEntity } from '../offchain-certificate/repositories/CertificateReadModel/CertificateReadModel.entity';
 import { OnChainWatcher } from './listeners/on-chain-certificates.listener';
+import { CertificateConfigModule } from '../config/certificate-config.module';
+import { CertificateConfigService } from '../config/certificate-config.service';
 
 const realCertificateProvider = {
     provide: ONCHAIN_CERTIFICATE_SERVICE_TOKEN,
@@ -61,15 +60,12 @@ const realCertificateProvider = {
     ],
     exports: [realCertificateProvider, OnChainCertificateFacade],
     imports: [
-        ConfigModule.forRoot({
-            isGlobal: true,
-            load: [getConfiguration]
-        }),
+        CertificateConfigModule,
         CqrsModule,
         BullModule.registerQueueAsync({
             name: blockchainQueueName,
-            inject: [ConfigService],
-            useFactory: (configService: ConfigService<Configuration>) => ({
+            inject: [CertificateConfigService],
+            useFactory: (configService: CertificateConfigService) => ({
                 settings: {
                     lockDuration: configService.get('CERTIFICATE_QUEUE_LOCK_DURATION')
                 }

--- a/packages/origin-247-certificate/test/setup.ts
+++ b/packages/origin-247-certificate/test/setup.ts
@@ -1,4 +1,4 @@
-import { CertificateUtils, Contracts } from '@energyweb/issuer';
+import { CertificateUtils } from '@energyweb/issuer';
 import { getConnectionToken, TypeOrmModule } from '@nestjs/typeorm';
 import { Logger } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
@@ -26,10 +26,8 @@ import {
 } from '../src/offchain-certificate/repositories/repository.keys';
 import { CertificateEventService } from '../src/offchain-certificate/repositories/CertificateEvent/CertificateEvent.service';
 import { Connection } from 'typeorm';
-import getConfiguration from '../src/offchain-certificate/config/configuration';
+import { getConfiguration } from '../src/config/configuration';
 import { BlockchainPropertiesService } from '../src/onchain-certificate/blockchain-properties.service';
-import { ConfigService } from '@nestjs/config';
-import { DeploymentPropertiesRepository } from '../src/onchain-certificate/repositories/deploymentProperties/deploymentProperties.repository';
 
 const testLogger = new Logger('e2e');
 


### PR DESCRIPTION
The way it works now all the config variables parsed by `origin-247-certificate` package will be accessed by
`origin-247-certificate-config.${someKey}` that prevents other modules and packages for parsing e.g. `ISSUE_BATCH_SIZE` as `string`