### PR TITLE
Claim algorithm performance tests

### DIFF
--- a/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
+++ b/packages/origin-247-claim/src/algorithms/spreadMatcher.ts
@@ -1,4 +1,4 @@
-import { omit, cloneDeep } from 'lodash';
+import { omit, cloneDeep, groupBy } from 'lodash';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export namespace SpreadMatcher {
@@ -33,15 +33,32 @@ export namespace SpreadMatcher {
     }
 
     /** Possible connection between two entities (one will satisfy another) */
-    type Route<T extends Entity, P extends Entity> = [T, P];
+    type RoutedEntity<T extends Entity, P extends Entity> = T & { routes: P[] };
+    type Route<T extends Entity, P extends Entity> = [RoutedEntity<T, P>, RoutedEntity<P, T>];
 
     interface RoundInput<T extends Entity, P extends Entity> {
         routes: Route<T, P>[];
-        entityGroups: [T[], P[]];
+        entityWithRoutes: [RoutedEntity<T, P>[], RoutedEntity<P, T>[]];
+        entityGroups: [RoutedEntity<T, P>[], RoutedEntity<P, T>[]];
+    }
+
+    interface GetMatchingRoundParams<T extends Entity, P extends Entity> {
+        groupPriority: {
+            id: string;
+            groupPriority: { id: string }[][];
+        }[][];
+        entityGroups: [RoutedEntity<T, P>[], RoutedEntity<P, T>[]];
+    }
+
+    interface MatchRoundResult<T extends Entity, P extends Entity> {
+        entities: Route<T, P>;
+        volume: BigNumber;
     }
 
     /**
      * @NOTE
+     *
+     * READ BEFORE CHANGING ANYTHING IN THE CODE
      *
      * ==============================
      * This code relies heavily on identity equality.
@@ -50,11 +67,15 @@ export namespace SpreadMatcher {
      *
      * Because entities may contain many fields, that are not supported by algorithm,
      * we would not know how to differentiate them: `id` can be not sufficient in many cases.
+     * For example we can have different certificates for the same generator.
      * At the same, priority groups will work with `id` only.
      *
      * This is why entities are differentiated using strict equality.
      * Multiple entities with the same `id` will be treated as belonging to the same priority group,
      * therefore they will be consumed/satisfied equally.
+     *
+     * Also many places, that may seem not declarative or strange may be made that way for performance reasons.
+     * Check for performance pull requests to see changes.
      * ==============================
      */
 
@@ -65,25 +86,34 @@ export namespace SpreadMatcher {
     export const spreadMatcher = <T extends Entity, P extends Entity>(
         originalData: Params<T, P>
     ): Result<T, P> => {
-        const data = cloneDeep(originalData);
-        const allRoundMatches = [] as Match<T, P>[][];
+        const clonedData = cloneDeep(originalData);
+        const data = {
+            ...clonedData,
+            entityGroups: [
+                clonedData.entityGroups[0].map((e) => ({ ...e, routes: [] as P[] })),
+                clonedData.entityGroups[1].map((e) => ({ ...e, routes: [] as T[] }))
+            ]
+        } as GetMatchingRoundParams<T, P>;
+
+        // We create simple Map for quick access during removing volumes in match
+        const entityMap = [
+            new Map(data.entityGroups[0].map((e) => [e, e])),
+            new Map(data.entityGroups[1].map((e) => [e, e]))
+        ] as const;
+
+        const matchRoundResults = [] as MatchRoundResult<T, P>[][];
 
         let i = 0;
         while ((i += 1)) {
-            if (i > 10000) {
+            if (i > 10_000) {
                 throw new Error(`
-                  Matching executed more than 10000 - it may mean, that something broke
-                  data: ${JSON.stringify(data)}
+                  Matching executed more than 10_000 - it may mean, that something broke
+                  data: ${JSON.stringify(clonedData)}
                   matches: not displayed, because of potential length
                 `);
             }
 
-            const allGroupsHaveVolume = [
-                data.entityGroups[0].some((v) => v.volume.gt(0)),
-                data.entityGroups[1].some((v) => v.volume.gt(0))
-            ].every(Boolean);
-
-            if (!allGroupsHaveVolume) {
+            if (data.entityGroups[0].length === 0 || data.entityGroups[1].length === 0) {
                 break;
             }
 
@@ -99,20 +129,31 @@ export namespace SpreadMatcher {
             const roundMatches = matchRound(roundInput);
 
             roundMatches.forEach((match) => {
-                const entity1 = data.entityGroups[0].find((e) => e === match.entities[0])!;
-                const entity2 = data.entityGroups[1].find((e) => e === match.entities[1])!;
+                const entity1 = entityMap[0].get(match.entities[0])!;
+                const entity2 = entityMap[1].get(match.entities[1])!;
 
                 entity1.volume = entity1.volume.sub(match.volume);
                 entity2.volume = entity2.volume.sub(match.volume);
             });
 
-            allRoundMatches.push(roundMatches);
+            matchRoundResults.push(roundMatches);
+            data.entityGroups = roundInput.entityGroups;
         }
 
+        // We remove routes, because they have circular dependency, and Jest doesn't like that
+        // (end user probably doesn't like that too)
+        // Type correctness is ensured by spread matcher result
+        data.entityGroups[0].forEach((e: any) => delete e.routes);
+        data.entityGroups[1].forEach((e: any) => delete e.routes);
+        matchRoundResults.flat().forEach((m) => m.entities.forEach((e: any) => delete e.routes));
+
         return {
-            matches: sumMatches(allRoundMatches.flat()).map(omitMatchVolumes) as Match<T, P>[],
-            roundMatches: allRoundMatches,
-            leftoverEntities: data.entityGroups
+            matches: sumMatches(matchRoundResults.flat()).map(omitMatchVolumes) as Match<T, P>[],
+            roundMatches: matchRoundResults,
+            leftoverEntities: [
+                data.entityGroups[0].filter((e) => e.volume.gt(0)),
+                data.entityGroups[1].filter((e) => e.volume.gt(0))
+            ] as [T[], P[]]
         };
     };
 
@@ -124,37 +165,39 @@ export namespace SpreadMatcher {
     };
 
     /**
-     * Multiple matches for the same entities can happen,
+     * Multiple matches for the same entities (routes) can happen,
      * and we want sum of these.
      */
     const sumMatches = <T extends Entity, P extends Entity>(
         matches: Match<T, P>[]
     ): Match<T, P>[] => {
-        const areMatchesSame = (match1: Match<T, P>, match2: Match<T, P>) => {
-            return (
-                match1.entities[0] === match2.entities[0] &&
-                match1.entities[1] === match2.entities[1]
-            );
-        };
+        const matchMap = new Map<Omit<T, 'volume'>, Map<Omit<P, 'volume'>, BigNumber>>();
 
-        return matches.reduce((sum, match) => {
-            const existingMatchIndex = sum.findIndex((s) => areMatchesSame(s, match));
+        // Insert entities into Map for quick access
+        // and sum volumes
+        matches.forEach((match) => {
+            const entity1Entry =
+                matchMap.get(match.entities[0]) ?? new Map<Omit<P, 'volume'>, BigNumber>();
 
-            if (existingMatchIndex >= 0) {
-                return sum.map((m, i) => {
-                    if (i === existingMatchIndex) {
-                        return {
-                            ...m,
-                            volume: m.volume.add(match.volume)
-                        };
-                    } else {
-                        return m;
-                    }
-                });
-            }
+            matchMap.set(match.entities[0], entity1Entry);
 
-            return [...sum, match];
-        }, [] as Match<T, P>[]);
+            const entity2Entry = entity1Entry.get(match.entities[1]) ?? BigNumber.from(0);
+
+            entity1Entry.set(match.entities[1], entity2Entry.add(match.volume));
+        });
+
+        // Unwind Map result
+        const entity1Entries = Array.from(matchMap.entries());
+        const result = entity1Entries.map(([entity1, entity1Entry]) => {
+            const entity2Entries = Array.from(entity1Entry.entries());
+
+            return entity2Entries.map(([entity2, volume]) => ({
+                entities: [entity1, entity2],
+                volume
+            }));
+        });
+
+        return result.flat() as Match<T, P>[];
     };
 
     /**
@@ -163,34 +206,17 @@ export namespace SpreadMatcher {
      * and that's easiest method to compute volume, that can be distributed without any errors in algorithm.
      */
     const computeSafeDistribution = <T extends Entity, P extends Entity>(
-        entities1: T[],
-        entities2: P[],
-        routes: Route<T, P>[]
+        entities1: RoutedEntity<T, P>[],
+        entities2: RoutedEntity<P, T>[]
     ) => {
-        const computeDistributedVolume = (entities: (T | P)[]) =>
-            entities.map((entity) => ({
-                entity,
-                volume: entity.volume.div(getCompetingEntities(routes, entity).length)
-            }));
-
-        return bigNumMinBy(
-            [...computeDistributedVolume(entities1), ...computeDistributedVolume(entities2)],
-            (e) => e.volume
+        const result = bigNumMinBy([...entities1, ...entities2], (e) =>
+            e.volume.div(e.routes.length)
         );
-    };
 
-    /**
-     * Return entities, that are connected to given entity by a route.
-     * This way we can find all entities that will be competing over another entity.
-     */
-    const getCompetingEntities = <T extends Entity, P extends Entity>(
-        routes: Route<T, P>[],
-        entity: T | P
-    ) => {
-        return routes
-            .filter((route) => route.includes(entity))
-            .flat()
-            .filter((competingEntity) => competingEntity !== entity);
+        return {
+            entity: result,
+            volume: result.volume.div(result.routes.length)
+        };
     };
 
     /**
@@ -198,18 +224,17 @@ export namespace SpreadMatcher {
      */
     const matchRound = <T extends Entity, P extends Entity>(
         input: RoundInput<T, P>
-    ): Match<T, P>[] => {
+    ): MatchRoundResult<T, P>[] => {
         const toDistribute = computeSafeDistribution(
-            input.entityGroups[0],
-            input.entityGroups[1],
-            input.routes
+            input.entityWithRoutes[0],
+            input.entityWithRoutes[1]
         );
 
         if (toDistribute.volume.eq(0)) {
-            const competingEntities = getCompetingEntities(input.routes, toDistribute.entity);
+            const competingEntities = toDistribute.entity.routes;
 
             // We need to check to which group entity to distribute belongs
-            const isEntityFirst = input.entityGroups[0].find((e) => e === toDistribute.entity);
+            const isEntityFirst = input.entityWithRoutes[0].some((e) => e === toDistribute.entity);
 
             // Each competing entity will receive one volume from entity to distribute,
             const entitiesToSatisfy = competingEntities.slice(
@@ -217,12 +242,14 @@ export namespace SpreadMatcher {
                 toDistribute.entity.volume.toNumber()
             );
 
-            return entitiesToSatisfy.map((connectedEntity) => ({
+            const result = entitiesToSatisfy.map((connectedEntity) => ({
                 entities: (isEntityFirst
                     ? [toDistribute.entity, connectedEntity]
-                    : [connectedEntity, toDistribute.entity]) as [T, P],
+                    : [connectedEntity, toDistribute.entity]) as Route<T, P>,
                 volume: BigNumber.from(1)
             }));
+
+            return result;
         }
 
         return input.routes.map((route) => ({
@@ -239,19 +266,19 @@ export namespace SpreadMatcher {
      * and make routes, that will be used for even spread.
      */
     const getRoundInput = <T extends Entity, P extends Entity>(
-        data: Params<T, P>
+        data: GetMatchingRoundParams<T, P>
     ): RoundInput<T, P> => {
-        const entitiesWithVolume = [
-            data.entityGroups[0].filter((e) => e.volume.gt(0)),
-            data.entityGroups[1].filter((e) => e.volume.gt(0))
+        const entities = [
+            prepareEntitiesForRoundInput(data.entityGroups[0]),
+            prepareEntitiesForRoundInput(data.entityGroups[1])
         ] as const;
 
-        const entity1Group = getFirstUsableGroup(data.groupPriority, entitiesWithVolume[0]);
+        const entity1Group = getFirstUsableGroup(data.groupPriority, entities[0].grouped);
 
         const routes = entity1Group.flatMap((entity1GroupEntry) => {
             const preferredEntity2Group = getFirstUsableGroup(
                 entity1GroupEntry.groupPriority,
-                entitiesWithVolume[1]
+                entities[1].grouped
             );
 
             return cartesian(
@@ -260,12 +287,54 @@ export namespace SpreadMatcher {
             );
         });
 
+        routes.forEach(([entity1, entity2]) => {
+            entity1.routes.push(entity2);
+            entity2.routes.push(entity1);
+        });
+
         return {
             routes,
-            entityGroups: [
-                entitiesWithVolume[0].filter((entity) => routes.some((e) => e[0].id === entity.id)),
-                entitiesWithVolume[1].filter((entity) => routes.some((e) => e[1].id === entity.id))
-            ]
+            entityWithRoutes: [
+                entities[0].flat.filter((entity) => entity.routes.length > 0),
+                entities[1].flat.filter((entity) => entity.routes.length > 0)
+            ],
+            entityGroups: [entities[0].flat, entities[1].flat]
+        };
+    };
+
+    /**
+     * Prepare entities for next matching round:
+     * 1. Filter out entities that are 0 volume
+     * 2. Reset entities routes
+     * 3. Group entities by `id` for fast access
+     */
+    const prepareEntitiesForRoundInput = <T extends Entity, P extends Entity>(
+        entities: RoutedEntity<T, P>[]
+    ): { grouped: Record<string, RoutedEntity<T, P>[]>; flat: RoutedEntity<T, P>[] } => {
+        const grouped: Record<string, RoutedEntity<T, P>[]> = {};
+        const flat: RoutedEntity<T, P>[] = [];
+        const entitiesLength = entities.length;
+
+        for (let i = 0; i < entitiesLength; i += 1) {
+            const entity = entities[i];
+
+            if (entity.volume.eq(0)) {
+                continue;
+            }
+
+            entity.routes = [];
+
+            if (!(entity.id in grouped)) {
+                grouped[entity.id] = [];
+            }
+
+            grouped[entity.id].push(entity);
+            flat.push(entity);
+        }
+
+        return {
+            grouped,
+            flat
         };
     };
 
@@ -275,26 +344,38 @@ export namespace SpreadMatcher {
      */
     const getFirstUsableGroup = <T extends { id: string }, P extends Entity>(
         groups: T[][],
-        entities: P[]
+        entities: Record<string, P[]>
     ): (T & { entities: P[] })[] => {
-        const groupsWithVolume = groups
-            .map((group) => {
-                const entitiesInGroup = group.map((entry) => ({
-                    ...entry,
-                    entities: entities.filter((e) => e.id === entry.id)
-                }));
+        const groupsWithEntities = groups.map((group) => {
+            const groupWithEntities = group.map((entry) => ({
+                ...entry,
+                entities: entities[entry.id] ?? []
+            }));
 
-                return entitiesInGroup;
-            })
-            .filter((group) => group.some((g) => g.entities.length > 0));
+            return groupWithEntities;
+        });
 
-        return groupsWithVolume[0] ?? [];
+        const firstAvailableEntry = groupsWithEntities.find((group) =>
+            group.some((g) => g.entities.length > 0)
+        );
+
+        return firstAvailableEntry ?? [];
     };
 
     const bigNumMinBy = <T>(collection: T[], cb: (v: T) => BigNumber): T => {
-        return collection.reduce((smallest, current) => {
-            return cb(current).lt(cb(smallest)) ? current : smallest;
-        }, collection[0]);
+        let minResult = cb(collection[0]);
+        let minItem = collection[0];
+
+        for (let i = 0; i < collection.length; i += 1) {
+            const currentResult = cb(collection[i]);
+
+            if (currentResult.lt(minResult)) {
+                minItem = collection[i];
+                minResult = currentResult;
+            }
+        }
+
+        return minItem;
     };
 
     const cartesian = <T, P>(arr1: T[], arr2: P[]): [T, P][] => {

--- a/packages/origin-247-claim/tests/spreadMatcher.performance.ts
+++ b/packages/origin-247-claim/tests/spreadMatcher.performance.ts
@@ -1,0 +1,91 @@
+import { SpreadMatcher } from '../src';
+import { times, sampleSize } from 'lodash';
+import { BigNumber } from '@ethersproject/bignumber';
+
+const createEntityGroups = (n: number, prefix: string, volume: number) => {
+    return times(n, (i) => ({
+        id: `${prefix}-${i}`,
+        volume: BigNumber.from(volume)
+    }));
+};
+
+const createPriorities = (n1: number, n2: number, prefix1: string, prefix2: string) => {
+    const generators = times(n2, (i2) => ({
+        id: `${prefix2}-${i2}`
+    }));
+
+    return times(n1, (i1) => ({
+        id: `${prefix1}-${i1}`,
+        groupPriority: [
+            sampleSize(generators, numberOfGeneratorsInPriorityGroup),
+            sampleSize(generators, numberOfGeneratorsInPriorityGroup)
+        ]
+    }));
+};
+
+const testPerf = (
+    numberOfGenerators: number,
+    numberOfConsumers: number
+): {
+    generators: number;
+    consumers: number;
+    timeData: number;
+    timeMatch: number;
+    matches: number;
+} => {
+    const start = Date.now();
+
+    console.log(
+        `Starting perf test for: ${numberOfGenerators} generators and ${numberOfConsumers} consumers`
+    );
+
+    const dataStart = Date.now();
+
+    const entities = [
+        createEntityGroups(numberOfConsumers, consumerPrefix, 5_000),
+        createEntityGroups(numberOfGenerators, generatorPrefix, 10_000)
+    ] as any;
+
+    const priorities = [
+        createPriorities(numberOfConsumers, numberOfGenerators, consumerPrefix, generatorPrefix)
+    ];
+
+    const dataEnd = Date.now();
+
+    const matchStart = Date.now();
+
+    console.log(`Staring matching`);
+
+    const result = SpreadMatcher.spreadMatcher({
+        entityGroups: entities,
+        groupPriority: priorities
+    });
+
+    const matchEnd = Date.now();
+
+    const end = Date.now();
+
+    console.log(`Test finished after ${end - start}ms`);
+
+    return {
+        generators: numberOfGenerators,
+        consumers: numberOfConsumers,
+        timeData: dataEnd - dataStart,
+        timeMatch: matchEnd - matchStart,
+        matches: result.matches.length
+    };
+};
+
+const generatorPrefix = 'gen';
+const consumerPrefix = 'con';
+const numberOfGeneratorsInPriorityGroup = 1;
+
+const results = [
+    // testPerf(50, 50),
+    // testPerf(100, 100),
+    // testPerf(500, 500),
+    // testPerf(1000, 1000),
+    testPerf(1000, 10000)
+];
+
+console.table(results);

--- a/packages/origin-247-claim/tests/spreadMatcher.spec.ts
+++ b/packages/origin-247-claim/tests/spreadMatcher.spec.ts
@@ -48,24 +48,10 @@ describe('spreadMatcher', () => {
             });
 
             // leftover consumptions
-            expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[0][1]).toEqual({
-                id: 'consumerB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[0]).toHaveLength(0);
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('2 consumers within same group - should distribute evenly between same priority consumers, regardless of consumptions', () => {
@@ -117,20 +103,9 @@ describe('spreadMatcher', () => {
                 id: 'consumerA',
                 volume: 50
             });
-            expect(result.leftoverEntities[0][1]).toEqual({
-                id: 'consumerB',
-                volume: 0
-            });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('2 consumers within same group - should distribute one more to first consumer when generations are indivisible equally', () => {
@@ -179,23 +154,12 @@ describe('spreadMatcher', () => {
 
             // leftover consumptions
             expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[0][1]).toEqual({
                 id: 'consumerB',
                 volume: 1
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('3 consumers within same group - should distribute evenly between same priority consumers', () => {
@@ -270,14 +234,7 @@ describe('spreadMatcher', () => {
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (1) to first consumer', () => {
@@ -352,14 +309,7 @@ describe('spreadMatcher', () => {
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('3 consumers within same group - should distribute last indivisible generation (2) from different generators to first consumer', () => {
@@ -439,14 +389,7 @@ describe('spreadMatcher', () => {
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('2 consumers within different groups - should satisfy higher priority group first', () => {
@@ -497,24 +440,12 @@ describe('spreadMatcher', () => {
 
             // leftover consumptions
             expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
-
-            expect(result.leftoverEntities[0][1]).toEqual({
                 id: 'consumerB',
                 volume: 50
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
 
         it('2 consumer priority groups, 2 consumer each - should satisfy higher priority group first', () => {
@@ -591,33 +522,17 @@ describe('spreadMatcher', () => {
 
             // leftover consumptions
             expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
-
-            expect(result.leftoverEntities[0][1]).toEqual({
-                id: 'consumerB',
-                volume: 0
-            });
-            expect(result.leftoverEntities[0][2]).toEqual({
                 id: 'consumerC',
                 volume: 50
             });
 
-            expect(result.leftoverEntities[0][3]).toEqual({
+            expect(result.leftoverEntities[0][1]).toEqual({
                 id: 'consumerD',
                 volume: 50
             });
 
             // excess generations
-            expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
-                id: 'generatorB',
-                volume: 0
-            });
+            expect(result.leftoverEntities[1]).toHaveLength(0);
         });
         // consumer priority end
     });
@@ -653,17 +568,10 @@ describe('spreadMatcher', () => {
             });
 
             // leftover consumptions
-            expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
+            expect(result.leftoverEntities[0]).toHaveLength(0);
 
             // excess generations
             expect(result.leftoverEntities[1][0]).toEqual({
-                id: 'generatorA',
-                volume: 0
-            });
-            expect(result.leftoverEntities[1][1]).toEqual({
                 id: 'generatorB',
                 volume: 100
             });
@@ -735,10 +643,7 @@ describe('spreadMatcher', () => {
             });
 
             // leftover consumptions
-            expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
+            expect(result.leftoverEntities[0]).toHaveLength(0);
 
             // excess generations
             expect(result.leftoverEntities[1][0]).toEqual({
@@ -791,10 +696,7 @@ describe('spreadMatcher', () => {
             });
 
             // leftover consumptions
-            expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
+            expect(result.leftoverEntities[0]).toHaveLength(0);
 
             // excess generations
             expect(result.leftoverEntities[1][0]).toEqual({
@@ -847,10 +749,7 @@ describe('spreadMatcher', () => {
             });
 
             // leftover consumptions
-            expect(result.leftoverEntities[0][0]).toEqual({
-                id: 'consumerA',
-                volume: 0
-            });
+            expect(result.leftoverEntities[0]).toHaveLength(0);
 
             // excess generations
             expect(result.leftoverEntities[1][0]).toEqual({


### PR DESCRIPTION
`yarn ts-node .\tests\spreadMatcher.performance.ts` in `origin-247-claim` directory.

So the optimization was mostly about using different data structure and algorithms for quick data access, because previously it was scanning large arrays over and over to find required data.

I don't see any other simple way to optimize matching round or round input.
Currently main issue is number of matching rounds - so even if round input and matching round are quite optimized, the number of matching rounds increases execution times a lot.

Number of round is really high, because this case where there is not enough energy to evenly distribute (volume to distribute = 0) comes up very often. In such case we don't process all possible routes, but only few of them. I cannot think of a way to optimize it.